### PR TITLE
Add logging to utility functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,10 @@ module.exports = {
    * (compressed, uncompressed, themed versions, etc.)
    */
   getStylesheet: function() {
-    return require.resolve('./qore.css'); // returns qore.css path for consistency
+    console.log(`getStylesheet is running with`); // entry log for helper call
+    const result = require.resolve('./qore.css'); // resolves stylesheet path
+    console.log(`getStylesheet is returning ${result}`); // logs resolved path
+    return result; // returns qore.css path for consistency
   },
   
   /*
@@ -69,7 +72,10 @@ module.exports = {
    * future features like variable preprocessing or theme selection.
    */
   getVariables: function() {
-    return require.resolve('./variables.css');
+    console.log(`getVariables is running with`); // entry log for helper call
+    const result = require.resolve('./variables.css'); // resolves variables path
+    console.log(`getVariables is returning ${result}`); // logs resolved path
+    return result; // returns variables.css path
   }
 };
 

--- a/scripts/utils/env-config.js
+++ b/scripts/utils/env-config.js
@@ -29,13 +29,16 @@
  * - Provides clear boundaries for safe operation
  */
 function parseEnvInt(envVar, defaultValue, minValue = 1, maxValue = 1000) {
+  console.log(`parseEnvInt is running with ${envVar},${defaultValue},${minValue},${maxValue}`); // entry log for debugging
   const parsed = parseInt(process.env[envVar], 10); // Parse environment variable as integer
   
   // Return default for any parsing failure or range violation
   if (Number.isNaN(parsed) || parsed < minValue || parsed > maxValue) {
+    console.log(`parseEnvInt is returning ${defaultValue}`); // logs fallback value
     return defaultValue;
   }
-  
+
+  console.log(`parseEnvInt is returning ${parsed}`); // logs validated value
   return parsed; // Return validated value
 }
 
@@ -52,8 +55,11 @@ function parseEnvInt(envVar, defaultValue, minValue = 1, maxValue = 1000) {
  * - Used for URLs, file paths, and other string configuration
  */
 function parseEnvString(envVar, defaultValue) {
+  console.log(`parseEnvString is running with ${envVar},${defaultValue}`); // entry log for debugging
   const value = process.env[envVar]; // Read environment variable
-  return value && value.trim() ? value.trim() : defaultValue; // Return trimmed value or default
+  const result = value && value.trim() ? value.trim() : defaultValue; // Determine result value
+  console.log(`parseEnvString is returning ${result}`); // logs returned string
+  return result; // Return trimmed value or default
 }
 
 /**
@@ -69,11 +75,17 @@ function parseEnvString(envVar, defaultValue) {
  * - Enables flexible boolean configuration across different deployment environments
  */
 function parseEnvBool(envVar, defaultValue = false) {
+  console.log(`parseEnvBool is running with ${envVar},${defaultValue}`); // entry log for debugging
   const value = process.env[envVar]; // Read environment variable
-  if (!value) return defaultValue; // Return default when undefined
-  
+  if (!value) {
+    console.log(`parseEnvBool is returning ${defaultValue}`); // logs fallback value
+    return defaultValue; // Return default when undefined
+  }
+
   const truthyValues = ['true', '1', 'yes', 'on']; // Standard truthy string representations
-  return truthyValues.includes(value.toLowerCase().trim()); // Case-insensitive boolean parsing
+  const result = truthyValues.includes(value.toLowerCase().trim()); // Case-insensitive boolean parsing
+  console.log(`parseEnvBool is returning ${result}`); // logs boolean result
+  return result; // Return parsed boolean
 }
 
 module.exports = {

--- a/scripts/utils/file-helpers.js
+++ b/scripts/utils/file-helpers.js
@@ -28,14 +28,19 @@ const qerrors = require('qerrors'); // Centralized error logging
  * - Enables hash-based cache busting across multiple scripts
  */
 async function readBuildHash() {
+  console.log(`readBuildHash is running with build.hash`); // logs entry for hash file reading
   try {
     const hash = await fs.readFile('build.hash', 'utf8'); // Read hash file content
-    return hash.trim(); // Remove any whitespace from hash
+    const trimmed = hash.trim(); // Prepare trimmed hash
+    console.log(`readBuildHash is returning ${trimmed}`); // logs successful hash
+    return trimmed; // Remove any whitespace from hash
   } catch (err) {
     if (err.code === 'ENOENT') {
+      console.log(`readBuildHash is returning ''`); // logs missing hash case
       return ''; // Return empty string when hash file doesn't exist
     }
     qerrors(err, 'Failed to read build hash', { filename: 'build.hash' }); // Log unexpected errors
+    console.log(`readBuildHash is returning ''`); // logs failure case
     return ''; // Return empty string for any read failure
   }
 }
@@ -53,10 +58,13 @@ async function readBuildHash() {
  * - Provides consistent API across different file operations
  */
 async function fileExists(filepath) {
+  console.log(`fileExists is running with ${filepath}`); // logs entry with file path
   try {
     await fs.access(filepath); // Check file accessibility
+    console.log(`fileExists is returning true`); // logs success case
     return true; // File exists and is accessible
   } catch (err) {
+    console.log(`fileExists is returning false`); // logs failure case
     return false; // File doesn't exist or isn't accessible
   }
 }
@@ -76,13 +84,16 @@ async function fileExists(filepath) {
  * - Enables graceful degradation when files are missing
  */
 async function readFileWithDefault(filepath, encoding = 'utf8', defaultContent = '') {
+  console.log(`readFileWithDefault is running with ${filepath},${encoding}`); // logs entry with parameters
   try {
     const content = await fs.readFile(filepath, encoding); // Read file with specified encoding
+    console.log(`readFileWithDefault is returning ${content}`); // logs file content
     return content; // Return file content
   } catch (err) {
     if (err.code !== 'ENOENT') {
       qerrors(err, 'Failed to read file', { filepath, encoding }); // Log unexpected errors
     }
+    console.log(`readFileWithDefault is returning ${defaultContent}`); // logs fallback content
     return defaultContent; // Return default content for missing files or errors
   }
 }


### PR DESCRIPTION
## Summary
- log entry and exit for env parsing helpers
- log entry and exit for file helper functions
- add logging for helper functions in main index module

## Testing
- `npm test` *(fails: tests 53 passed, 9 failed)*

------
https://chatgpt.com/codex/tasks/task_b_684921758d4c832282fe4bc34a137087