### PR TITLE
Add environment commentary

### DIFF
--- a/replit.nix
+++ b/replit.nix
@@ -1,7 +1,15 @@
 { pkgs }: {
-  # Nix environment ensuring TypeScript and VS Code language support on Replit
-  deps = [ # packages made available in the shell
-    pkgs.nodePackages.vscode-langservers-extracted
-    pkgs.nodePackages.typescript-language-server
+  # REPLIT NIX DERIVATION - DEVELOPMENT ENVIRONMENT DEFINITION
+  #
+  # PURPOSE AND RATIONALE:
+  # This file defines the minimal Nix environment required when running on
+  # Replit. Only a small subset of packages is needed because the project is a
+  # static site with Node-based tooling. Providing just the language servers
+  # keeps the environment lightweight while enabling editor features such as
+  # IntelliSense and linting. Additional dependencies can be added here if
+  # future development tooling requires them.
+  deps = [                                  # packages made available in the shell
+    pkgs.nodePackages.vscode-langservers-extracted  # provides HTML/CSS/JS language support
+    pkgs.nodePackages.typescript-language-server     # supports TS/JS editing features
   ];
 }


### PR DESCRIPTION
## Summary
- expand the comments in `replit.nix`

## Testing
- `npm test` *(fails: 53 passing, 9 failing)*

------
https://chatgpt.com/codex/tasks/task_b_684929e6c82c8322a58057d8b0142adf