### PR TITLE
Validate attempts before retry loop

### DIFF
--- a/scripts/request-retry.js
+++ b/scripts/request-retry.js
@@ -59,8 +59,10 @@ const {wait} = require('./utils/delay'); // Centralized delay utility function
  * - Network reality (allows for slow connections)
  * - Resource management (prevents hanging connections)
  */
-async function fetchRetry(url,opts={},attempts=3){ 
-  console.log(`fetchRetry is running with ${url},${attempts}`); // Logs request initiation with parameters
+async function fetchRetry(url,opts={},attempts=3){
+  console.log(`fetchRetry is running with ${url},${attempts}`); // logs entry with parameters
+
+  if(attempts < 1){ console.log(`fetchRetry is returning attempts must be >0`); throw new Error('attempts must be >0'); } // validates positive attempt count
  
  /*
   * TIMEOUT CONFIGURATION

--- a/test/request-retry.test.js
+++ b/test/request-retry.test.js
@@ -111,3 +111,20 @@ describe('fetchRetry fails after attempts', {concurrency:false}, () => {
     await assert.rejects(fetchRetry('http://c', {}, 2)); // validates error is thrown after 2 failed attempts
   });
 });
+
+/*
+ * PARAMETER VALIDATION TESTING
+ *
+ * TESTING SCOPE:
+ * Validates that fetchRetry throws an error when provided
+ * with less than one attempt, ensuring caller configuration
+ * is correct before any network request occurs.
+ */
+describe('fetchRetry invalid attempts parameter', {concurrency:false}, () => {
+  it('throws when attempts is below one', async () => {
+    await assert.rejects(
+      async () => await fetchRetry('http://d', {}, 0), // executes with invalid attempts
+      (err) => err.message === 'attempts must be >0' // validates rejection reason
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- validate `attempts` argument in `fetchRetry`
- adjust logging for early exit
- test zero-attempt behavior
- cover invalid attempts in request-retry tests

## Testing
- `node --test --test-concurrency=1` *(fails: Command failed: npx postcss qore.css -o core.min.css)*

------
https://chatgpt.com/codex/tasks/task_b_684bc72e1af0832292b87700c04e7e6f