### PR TITLE
Enforce build hash for performance script

### DIFF
--- a/test/performance.test.js
+++ b/test/performance.test.js
@@ -57,6 +57,7 @@ describe('run trims history', {concurrency:false}, () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perf-')); //(temporary directory for file operations)
     const history = Array.from({length:55}, (_,i)=>({timestamp:`${i}`, results:{}})); //(pre-seeded history)
     fs.writeFileSync(path.join(tmpDir,'performance-results.json'), JSON.stringify(history)); //(create initial file)
+    fs.writeFileSync(path.join(tmpDir, 'build.hash'), 'abcdef'); //(mock hash file required by run)
     process.chdir(tmpDir); //(switch cwd for script)
     process.argv = ['node','scripts/performance.js','1','--json']; //(setup argv for run function)
   });


### PR DESCRIPTION
## Summary
- require `build.hash` at the start of the performance run script
- return the first measured average time
- adjust performance tests to provide the hash file

## Testing
- `npm test` *(fails: E403 when installing postcss)*

------
https://chatgpt.com/codex/tasks/task_b_684bc74524d083229ea9371f9d091098