### PR TITLE
Handle missing build hash in performance script

### DIFF
--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -152,7 +152,7 @@ async function measureUrl(url, count){
 async function run(){
  console.log(`run is running with ${process.argv.length}`); // Logs execution start for monitoring
  try {
-  await fs.promises.access('build.hash'); // Ensures build.hash exists before reading to force ENOENT when absent
+  try { await fs.promises.access('build.hash'); } catch(err){ if(err.code==='ENOENT'){ console.log(`run build.hash not found`); } else { throw err; } } // Catches missing hash file to allow fallback logic
   /*
    * BUILD HASH INTEGRATION
    * Rationale: Tests must use the current CSS version to provide meaningful
@@ -161,8 +161,8 @@ async function run(){
    * cases where build hasn't run yet.
    */
   const {readBuildHash} = require('./utils/file-helpers'); // Centralized file system utilities
-  const hash = await readBuildHash(); // Read current build hash with error handling 
-  const fileName = hash ? `core.${hash}.min.css` : `core.min.css`; 
+  const hash = await readBuildHash(); // Read current build hash with error handling
+  let fileName = `core.${hash}.min.css`; if(!hash){ fileName = `core.min.css`; } // Falls back when hash is empty
   
   /*
    * CDN ENDPOINT CONFIGURATION

--- a/test/error-handling.test.js
+++ b/test/error-handling.test.js
@@ -124,13 +124,9 @@ describe('performance error handling', {concurrency:false}, () => {
     process.env.CODEX = 'True'; // forces offline mode for predictable testing
     delete require.cache[require.resolve('../scripts/performance')]; // clears module cache for fresh import
     const performance = require('../scripts/performance'); // imports performance module after cache clearing
-    
-    await assert.rejects(
-      async () => await performance.run(), // executes performance run without hash file
-      (err) => {
-        return err.code === 'ENOENT' && err.path.includes('build.hash'); // validates specific hash file not found error
-      }
-    );
+
+    const result = await performance.run(); // executes performance run without hash file
+    assert.strictEqual(typeof result, 'number'); // verifies successful numeric result
     delete process.env.CODEX; // cleans up environment flag
   });
 

--- a/test/performance.test.js
+++ b/test/performance.test.js
@@ -71,3 +71,20 @@ describe('run trims history', {concurrency:false}, () => {
     assert.strictEqual(file.length, 50); //(ensure trimming to max)
   });
 });
+
+describe('run without build.hash', {concurrency:false}, () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perf-')); //(temporary directory for file operations)
+    process.chdir(tmpDir); //(switch cwd for script without hash)
+    process.argv = ['node','scripts/performance.js','1']; //(setup argv)
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, {recursive:true, force:true}); //(remove temp directory)
+    process.argv = ['node','']; //(reset argv)
+  });
+  it('returns numeric result', async () => {
+    const result = await performance.run(); //(execute run without hash)
+    assert.strictEqual(typeof result, 'number'); //(validate numeric return)
+  });
+});


### PR DESCRIPTION
## Summary
- catch errors when accessing `build.hash` in `scripts/performance.js`
- default to `core.min.css` when no hash read
- test `run()` without `build.hash`
- update error handling tests accordingly

## Testing
- `node --test --test-concurrency=1`

------
https://chatgpt.com/codex/tasks/task_b_684bd62e57388322b3974522848eef22