### PR TITLE
Implement shared logger utility

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -29,7 +29,7 @@ const crypto = require('crypto'); // Cryptographic functions for generating cont
 const {createGzip, createBrotliCompress} = require('zlib'); // Streaming compressors for optimized output
 const {pipeline} = require('stream/promises'); // Promise based pipeline for stream control
 const execFileAsync = promisify(execFile); // Promise-wrapped execFile for consistent async patterns
-const qerrors = require('qerrors'); // Centralized error logging with contextual information
+const qerrors = require('./utils/logger'); // Centralized error logging with contextual information
 
 /*
  * MAIN BUILD FUNCTION

--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -23,7 +23,7 @@
 
 const fetchRetry = require('./request-retry'); // HTTP client with retry logic for handling network failures
 const {performance} = require('perf_hooks'); // High-resolution timing API for accurate measurements
-const qerrors = require('qerrors'); // Centralized error logging with contextual information
+const qerrors = require('./utils/logger'); // Centralized error logging with contextual information
 const fs = require('fs'); // File system operations for reading/writing test results
 // Manual concurrency control implementation to replace p-limit per REPLITAGENT.md constraints
 const {parseEnvInt, parseEnvString} = require('./utils/env-config'); // Centralized environment configuration utilities

--- a/scripts/purge-cdn.js
+++ b/scripts/purge-cdn.js
@@ -23,7 +23,7 @@
  * waiting for natural cache expiration, improving deployment reliability.
  */
 
-const qerrors = require('qerrors'); // Centralized error logging with contextual information
+const qerrors = require('./utils/logger'); // Centralized error logging with contextual information
 const fs = require('fs').promises; // Node promise-based filesystem for async use
 const fetchRetry = require('./request-retry'); // Retry wrapper for HTTP requests
 

--- a/scripts/request-retry.js
+++ b/scripts/request-retry.js
@@ -25,7 +25,7 @@
 const axios = require('axios'); // Robust HTTP client library with comprehensive feature set
 const http = require('node:http'); // Node HTTP used for keep-alive agent
 const https = require('node:https'); // Node HTTPS used for keep-alive agent
-const qerrors = require('qerrors'); // Centralized error logging with contextual information preservation
+const qerrors = require('./utils/logger'); // Centralized error logging with contextual information preservation
 const {parseEnvInt} = require('./utils/env-config'); // Centralized environment configuration utilities
 const socketLimit = parseEnvInt('SOCKET_LIMIT', 50, 1, 1000); // validates range 1-1000 with default 50
 const axiosInstance = axios.create({httpAgent:new http.Agent({keepAlive:true,maxSockets:socketLimit}),httpsAgent:new https.Agent({keepAlive:true,maxSockets:socketLimit})}); // axios instance using variable connection limit

--- a/scripts/updateHtml.js
+++ b/scripts/updateHtml.js
@@ -21,7 +21,7 @@
  */
 
 const fs = require('fs').promises; // File system operations using promises for consistent async patterns
-const qerrors = require('qerrors'); // Centralized error logging with contextual information
+const qerrors = require('./utils/logger'); // Centralized error logging with contextual information
 
 /*
  * HTML UPDATE FUNCTION

--- a/scripts/utils/file-helpers.js
+++ b/scripts/utils/file-helpers.js
@@ -14,7 +14,7 @@
  */
 
 const fs = require('fs').promises; // Promise-based file system operations
-const qerrors = require('qerrors'); // Centralized error logging
+const qerrors = require('./logger'); // Centralized error logging
 
 /**
  * BUILD HASH FILE READER

--- a/scripts/utils/logger.js
+++ b/scripts/utils/logger.js
@@ -1,0 +1,20 @@
+// ERROR LOGGER UTILITY
+//
+// PURPOSE AND RATIONALE:
+// Provides a consistent error logging function across all scripts.
+// It attempts to use the qerrors module for structured error logging
+// but falls back to console.error when qerrors is unavailable.
+
+let logger;
+try {
+  logger = require('qerrors'); // Use qerrors when available for structured error logging
+} catch (err) {
+  function fallbackLogger(error, msg, ctx) { // provides console.error fallback when qerrors missing
+    console.log(`fallbackLogger is running with ${error},${msg}`); // entry log for debugging
+    console.error(error, msg, ctx); // basic error output
+    console.log(`fallbackLogger is returning undefined`); // exit log for debugging
+  }
+  logger = fallbackLogger; // assign fallback implementation
+}
+
+module.exports = logger; // exports chosen logger function for use across scripts


### PR DESCRIPTION
## Summary
- add utility that loads `qerrors` or falls back to `console.error`
- update build/performance/purge-cdn/request-retry/updateHtml scripts to use new logger
- update file-helpers in utils to consume new logger

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/postcss)*

------
https://chatgpt.com/codex/tasks/task_b_684bd63da7008322949d9c30c65c9665