### PR TITLE
Refactor request retry with axios-retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "lint": "stylelint qore.css variables.css",
     "test": "node --test --test-concurrency=1"
   },
+  "dependencies": {
+    "axios-retry": "^3.7.0"
+  },
   "devDependencies": {
     "autoprefixer": "^10.4.14",
     "axios": "^1.6.0",

--- a/scripts/request-retry.js
+++ b/scripts/request-retry.js
@@ -25,25 +25,12 @@
 const axios = require('axios'); // Robust HTTP client library with comprehensive feature set
 const http = require('node:http'); // Node HTTP used for keep-alive agent
 const https = require('node:https'); // Node HTTPS used for keep-alive agent
+const axiosRetry = require('axios-retry'); // Axios plugin providing automated retry support
 const qerrors = require('./utils/logger'); // Centralized error logging with contextual information preservation
 const {parseEnvInt} = require('./utils/env-config'); // Centralized environment configuration utilities
 const socketLimit = parseEnvInt('SOCKET_LIMIT', 50, 1, 1000); // validates range 1-1000 with default 50
 const axiosInstance = axios.create({httpAgent:new http.Agent({keepAlive:true,maxSockets:socketLimit}),httpsAgent:new https.Agent({keepAlive:true,maxSockets:socketLimit})}); // axios instance using variable connection limit
-
-/*
- * DELAY UTILITY FUNCTION
- * 
- * Rationale: Implements non-blocking delays for exponential backoff strategy.
- * Promise-based approach integrates cleanly with async/await patterns.
- * Logging provides visibility into retry timing for debugging purposes.
- */
-const {setTimeout: wait} = require('node:timers/promises'); // Promise-based timer for delays
-
-async function delay(ms, log){
-  if(log){ console.log(`delay is running with ${ms}`); } // logs delay start for debugging
-  await wait(ms); // non-blocking wait using built-in promise timer
-  if(log){ console.log(`delay is returning undefined`); } // logs completion for visibility
-} // wrapper preserves previous logging behavior
+axiosRetry(axiosInstance,{retryDelay:axiosRetry.exponentialDelay}); // configures plugin with exponential backoff
 
 /*
  * HTTP REQUEST WITH EXPONENTIAL BACKOFF RETRY LOGIC
@@ -78,59 +65,14 @@ async function fetchRetry(url,opts={},attempts=3){
   */
  if(!('timeout' in opts)){ opts.timeout = 10000; } 
  
-  /*
-   * RETRY LOOP WITH EXPONENTIAL BACKOFF
-   * Rationale: Loop structure enables clean retry logic with progressive delays.
-   * Each iteration represents one complete request attempt with error handling.
-   */
-  for(let i=1;i<=attempts;i++){ 
-   try{
-    /*
-     * HTTP REQUEST EXECUTION
-     * Rationale: axiosInstance.get provides reliable HTTP client with good error handling,
-     * timeout support, and comprehensive response object. Options object allows
-     * caller to specify responseType, headers, and other request configuration.
-     */
-    const res=await axiosInstance.get(url,opts); // uses persistent axios instance for all retries
-   console.log(`fetchRetry is returning ${res.status}`); // Logs successful response status
-   return res; // Returns complete axios response object for caller processing
-  }catch(err){
-   /*
-    * RESOURCE CLEANUP
-    * Rationale: Ensures failed requests don't leak resources, particularly important
-    * for connection pooling and memory management in high-retry scenarios.
-    */
-   if(err.request) {
-     err.request.destroy && err.request.destroy(); // Cleanup hanging request if possible
-   }
-   /*
-    * ERROR LOGGING WITH CONTEXT
-    * Rationale: Each failed attempt is logged with context to enable debugging
-    * of network issues, server problems, or configuration errors. Attempt number
-    * helps identify whether issues are consistent or intermittent.
-    */
-   qerrors(err,`fetch attempt ${i}`,{url,attempt:i}); 
-   
-   /*
-    * FINAL ATTEMPT HANDLING
-    * Rationale: After exhausting all retry attempts, the error is re-thrown
-    * to allow calling code to handle the failure appropriately. This prevents
-    * infinite retry loops while preserving error information.
-    */
-   if(i===attempts){ 
-    throw err; // Re-throws final error for caller to handle
-   }
-   
-   /*
-    * EXPONENTIAL BACKOFF DELAY CALCULATION
-    * Rationale: 2^(attempt-1) * 100ms creates exponential backoff:
-    * - Attempt 1 failure: 100ms delay before attempt 2
-    * - Attempt 2 failure: 200ms delay before attempt 3
-    * This pattern respects struggling servers while enabling quick recovery.
-    */
-  const delayMs=2**(i-1)*100; // calculates exponential backoff in ms
-  await delay(delayMs, true); // waits before next retry attempt with logging
-  }
+ try{ // executes request through axios-retry configured instance
+  const res = await axiosInstance.get(url,{...opts,'axios-retry':{retries:attempts-1}}); // per-request retry count
+  console.log(`fetchRetry is returning ${res.status}`); // Logs successful response status
+  return res; // Returns complete axios response object for caller processing
+ }catch(err){
+  if(err.request){ err.request.destroy && err.request.destroy(); } // cleans up failed request
+  qerrors(err,`fetch failed`,{url,attempts}); // logs failure with context
+  throw err; // re-throws error after retries exhausted
  }
 }
 


### PR DESCRIPTION
## Summary
- use axios-retry for automatic retry handling
- wire axios-retry into axiosInstance
- stub axios-retry in tests
- adjust request-retry tests for module reload
- add axios-retry dependency

## Testing
- `npm test` *(fails: missing modules during build tests)*

------
https://chatgpt.com/codex/tasks/task_b_684d0dfc5e1483229f5a4e14ebe3f328