### PR TITLE
Centralize delay utility

### DIFF
--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -27,6 +27,7 @@ const qerrors = require('./utils/logger'); // Centralized error logging with con
 const fs = require('fs'); // File system operations for reading/writing test results
 // Manual concurrency control implementation to replace p-limit per REPLITAGENT.md constraints
 const {parseEnvInt, parseEnvString} = require('./utils/env-config'); // Centralized environment configuration utilities
+const delay = require('./utils/delay'); // shared delay utility for optional waits
 const CDN_BASE_URL = parseEnvString('CDN_BASE_URL', 'https://cdn.jsdelivr.net'); // Environment-configurable CDN endpoint
 const MAX_CONCURRENCY = parseEnvInt('MAX_CONCURRENCY', 50, 1, 1000); // validates range 1-1000 with default 50
 const QUEUE_LIMIT = parseEnvInt('QUEUE_LIMIT', 5, 1, 100); // validates range 1-100 with default 5
@@ -40,12 +41,7 @@ const HISTORY_MAX = 50; // maximum entries kept in performance history file
  * testing the measurement logic without requiring internet connectivity.
  * 100ms delay approximates fast CDN response times.
  */
-const {setTimeout: wait} = require('node:timers/promises'); // Promise-based timer for mock delays
-async function delay(ms, log){
-  if(log){ console.log(`delay is running with ${ms}`); } // logs mock delay start
-  await wait(ms); // built-in non-blocking wait
-  if(log){ console.log(`delay is returning undefined`); } // logs delay completion
-} // replicates previous delay util with logging
+// delay imported from util ensures consistent mock wait behavior across scripts
 
 /*
  * SINGLE REQUEST TIMING MEASUREMENT

--- a/scripts/request-retry.js
+++ b/scripts/request-retry.js
@@ -27,23 +27,16 @@ const http = require('node:http'); // Node HTTP used for keep-alive agent
 const https = require('node:https'); // Node HTTPS used for keep-alive agent
 const qerrors = require('./utils/logger'); // Centralized error logging with contextual information preservation
 const {parseEnvInt} = require('./utils/env-config'); // Centralized environment configuration utilities
+const delay = require('./utils/delay'); // shared delay utility with optional logging
 const socketLimit = parseEnvInt('SOCKET_LIMIT', 50, 1, 1000); // validates range 1-1000 with default 50
 const axiosInstance = axios.create({httpAgent:new http.Agent({keepAlive:true,maxSockets:socketLimit}),httpsAgent:new https.Agent({keepAlive:true,maxSockets:socketLimit})}); // axios instance using variable connection limit
 
 /*
  * DELAY UTILITY FUNCTION
- * 
+ *
  * Rationale: Implements non-blocking delays for exponential backoff strategy.
- * Promise-based approach integrates cleanly with async/await patterns.
- * Logging provides visibility into retry timing for debugging purposes.
+ * Centralized implementation removes duplication across scripts.
  */
-const {setTimeout: wait} = require('node:timers/promises'); // Promise-based timer for delays
-
-async function delay(ms, log){
-  if(log){ console.log(`delay is running with ${ms}`); } // logs delay start for debugging
-  await wait(ms); // non-blocking wait using built-in promise timer
-  if(log){ console.log(`delay is returning undefined`); } // logs completion for visibility
-} // wrapper preserves previous logging behavior
 
 /*
  * HTTP REQUEST WITH EXPONENTIAL BACKOFF RETRY LOGIC

--- a/scripts/utils/delay.js
+++ b/scripts/utils/delay.js
@@ -1,0 +1,17 @@
+/*
+ * DELAY UTILITY
+ *
+ * PURPOSE AND RATIONALE:
+ * Provides a reusable promise based delay used across multiple scripts.
+ * Centralizing this avoids duplication while preserving consistent logging behavior.
+ */
+
+const {setTimeout: wait} = require('node:timers/promises'); // uses built in promise timer for async waits
+
+async function delay(ms, log){
+  if(log){ console.log(`delay is running with ${ms}`); } // entry log when enabled
+  await wait(ms); // asynchronous wait without blocking event loop
+  if(log){ console.log(`delay is returning undefined`); } // exit log when enabled
+} // shared delay utility with optional logging
+
+module.exports = delay; // exposes delay function for reuse across scripts


### PR DESCRIPTION
## Summary
- add `scripts/utils/delay.js` for shared async wait
- switch scripts to use the shared delay

## Testing
- `node --test --test-concurrency=1` *(fails: 5 tests failed)*

------
https://chatgpt.com/codex/tasks/task_b_684d0e8105ac832289acfa7f4a2fae64