### PR TITLE
Refactor env config usage

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -30,6 +30,7 @@ const {createGzip, createBrotliCompress} = require('zlib'); // Streaming compres
 const {pipeline} = require('stream/promises'); // Promise based pipeline for stream control
 const execFileAsync = promisify(execFile); // Promise-wrapped execFile for consistent async patterns
 const qerrors = require('./utils/logger'); // Centralized error logging with contextual information
+const {parseEnvBool} = require('./utils/env-config'); // standardized boolean env parsing for CODEX detection
 
 /*
  * MAIN BUILD FUNCTION
@@ -55,10 +56,10 @@ async function build(){
    * The qore.css input is processed and output as core.min.css with optimizations applied.
    * Using execFile instead of exec prevents shell injection attacks.
    */
-  if(process.env.CODEX === `True`){
-   await fsp.copyFile('qore.css','core.min.css'); // Skips postcss in offline mode
+  if(parseEnvBool('CODEX')){ // checks offline mode using shared parser for consistency
+   await fsp.copyFile('qore.css','core.min.css'); // Skips postcss when offline
   } else {
-   await execFileAsync('npx', ['postcss','qore.css','-o','core.min.css']); // Runs postcss normally
+   await execFileAsync('npx', ['postcss','qore.css','-o','core.min.css']); // Runs postcss when online
   }
   
   /*

--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -26,7 +26,7 @@ const {performance} = require('perf_hooks'); // High-resolution timing API for a
 const qerrors = require('./utils/logger'); // Centralized error logging with contextual information
 const fs = require('fs'); // File system operations for reading/writing test results
 // Manual concurrency control implementation to replace p-limit per REPLITAGENT.md constraints
-const {parseEnvInt, parseEnvString} = require('./utils/env-config'); // Centralized environment configuration utilities
+const {parseEnvInt, parseEnvString, parseEnvBool} = require('./utils/env-config'); // adds boolean parser for CODEX detection
 const CDN_BASE_URL = parseEnvString('CDN_BASE_URL', 'https://cdn.jsdelivr.net'); // Environment-configurable CDN endpoint
 const MAX_CONCURRENCY = parseEnvInt('MAX_CONCURRENCY', 50, 1, 1000); // validates range 1-1000 with default 50
 const QUEUE_LIMIT = parseEnvInt('QUEUE_LIMIT', 5, 1, 100); // validates range 1-100 with default 5
@@ -70,7 +70,7 @@ async function getTime(url){
    * Rationale: Development environments may not have internet access.
    * CODEX environment flag enables testing measurement logic offline.
    */
-  if(process.env.CODEX === `True`){
+  if(parseEnvBool('CODEX')){ // detects offline mode using shared parser
    await delay(100, true); // Simulates network delay in offline environment with logging
   } else {
    /*

--- a/scripts/purge-cdn.js
+++ b/scripts/purge-cdn.js
@@ -26,6 +26,7 @@
 const qerrors = require('./utils/logger'); // Centralized error logging with contextual information
 const fs = require('fs').promises; // Node promise-based filesystem for async use
 const fetchRetry = require('./request-retry'); // Retry wrapper for HTTP requests
+const {parseEnvBool} = require('./utils/env-config'); // standardized boolean env parsing for CODEX detection
 
 /*
  * CDN CACHE PURGE FUNCTION
@@ -57,7 +58,7 @@ async function purgeCdn(file){
    * or may want to avoid making actual purge requests during testing.
    * Mock response enables testing of purge logic without affecting production CDN.
    */
-  if(process.env.CODEX === `True`){ 
+  if(parseEnvBool('CODEX')){ // determines offline mode using shared parser
    console.log(`purgeCdn is returning 200`); // Logs mock success response
    return 200; // Returns HTTP 200 status code indicating successful purge
   }

--- a/scripts/updateHtml.js
+++ b/scripts/updateHtml.js
@@ -22,6 +22,7 @@
 
 const fs = require('fs').promises; // File system operations using promises for consistent async patterns
 const qerrors = require('./utils/logger'); // Centralized error logging with contextual information
+const {parseEnvString} = require('./utils/env-config'); // standardizes CDN URL retrieval with fallback
 
 /*
  * HTML UPDATE FUNCTION
@@ -66,7 +67,7 @@ async function updateHtml(){
    * for different deployment environments (development, staging, production).
    * jsDelivr chosen as default for its reliability and global CDN presence.
    */
-  const cdnUrl = process.env.CDN_BASE_URL || `https://cdn.jsdelivr.net`; // Allows environment-defined CDN URL
+  const cdnUrl = parseEnvString('CDN_BASE_URL', 'https://cdn.jsdelivr.net'); // retrieves CDN url with fallback to jsDelivr
   
   /*
    * CSS HASH REPLACEMENT


### PR DESCRIPTION
## Summary
- standardize CODEX checks using parseEnvBool
- use parseEnvString for CDN base URL in HTML updater

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/postcss)*

------
https://chatgpt.com/codex/tasks/task_b_684d0e876c588322a2f482d877895166