### PR TITLE
Remove unused delay module from request-retry

### DIFF
--- a/scripts/request-retry.js
+++ b/scripts/request-retry.js
@@ -32,8 +32,7 @@ const socketLimit = parseEnvInt('SOCKET_LIMIT', 50, 1, 1000); // validates range
 const axiosInstance = axios.create({httpAgent:new http.Agent({keepAlive:true,maxSockets:socketLimit}),httpsAgent:new https.Agent({keepAlive:true,maxSockets:socketLimit})}); // axios instance using variable connection limit
 
 axiosRetry(axiosInstance,{retryDelay:axiosRetry.exponentialDelay}); // configures plugin with exponential backoff
-
-const delay = require('./utils/delay'); // shared delay utility for retry backoff
+// delay module removed since axiosRetry handles exponential backoff internally // change rationale comment
 
 
 /*


### PR DESCRIPTION
## Summary
- trim unused `delay` module require in `request-retry.js`

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_b_684d37e79b4c83228d85ded6df2aa0bc