### PR TITLE
Update CDN purge script comments

### DIFF
--- a/scripts/purge-cdn.js
+++ b/scripts/purge-cdn.js
@@ -128,7 +128,7 @@ async function run(){
   qerrors(err, `run failed`, {args:process.argv.slice(2)}); // Logs error with command line context
   throw err; // Re-throws error to signal purge failure to calling processes
  }
-} // run function is intentionally not exported or executed automatically
+} // run function is exported but not executed automatically for manual control
 
 module.exports = {purgeCdn, run}; // exports functions for unit testing and reuse
 


### PR DESCRIPTION
## Summary
- adjust comment in `scripts/purge-cdn.js` to note that `run` is exported

## Testing
- `npm test` *(fails: test failures)*

------
https://chatgpt.com/codex/tasks/task_b_684dfc36f5e883228f790f308ee0652a