### PR TITLE
Handle missing build hash in updateHtml

### DIFF
--- a/test/error-handling.test.js
+++ b/test/error-handling.test.js
@@ -198,16 +198,12 @@ describe('updateHtml error handling', {concurrency:false}, () => {
    */
   it('handles missing build.hash file', async () => {
     fs.writeFileSync(path.join(tmpDir, 'index.html'), '<link href="qore.css">'); // creates basic HTML file
-    
+
     delete require.cache[require.resolve('../scripts/updateHtml')]; // clears module cache for fresh import
     const updateHtml = require('../scripts/updateHtml'); // imports updateHtml function after cache clearing
-    
-    await assert.rejects(
-      async () => await updateHtml(), // executes updateHtml without hash file
-      (err) => {
-        return err.code === 'ENOENT' && err.path.includes('build.hash'); // validates specific hash file not found error
-      }
-    );
+
+    const code = await updateHtml(); // executes updateHtml without hash file and captures return code
+    assert.strictEqual(code, 1); // validates error code return when hash missing
   });
 });
 


### PR DESCRIPTION
## Summary
- check build.hash before reading in updateHtml
- handle missing hash with qerrors and return code 1
- update error-handling tests for new behavior

## Testing
- `npm test` *(fails: Cannot find module 'env-var')*

------
https://chatgpt.com/codex/tasks/task_b_684dfc3df0608322882e61470c4ee0ed