### PR TITLE
Add numeric attempts validation

### DIFF
--- a/scripts/request-retry.js
+++ b/scripts/request-retry.js
@@ -58,6 +58,8 @@ axiosRetry(axiosInstance,{retryDelay:axiosRetry.exponentialDelay}); // configure
 async function fetchRetry(url,opts={},attempts=3){
   console.log(`fetchRetry is running with ${url},${attempts}`); // logs entry with parameters
 
+  if(typeof attempts!=='number'||Number.isNaN(attempts)){ console.log(`fetchRetry is returning attempts must be numeric`); throw new Error('attempts must be numeric'); } // validates numeric attempt parameter
+
   if(attempts < 1){ console.log(`fetchRetry is returning attempts must be >0`); throw new Error('attempts must be >0'); } // validates positive attempt count
  
  /*

--- a/test/request-retry.test.js
+++ b/test/request-retry.test.js
@@ -132,3 +132,25 @@ describe('fetchRetry invalid attempts parameter', {concurrency:false}, () => {
     );
   });
 });
+
+/*
+ * NON-NUMERIC ATTEMPT VALIDATION
+ *
+ * TESTING SCOPE:
+ * Ensures fetchRetry rejects when attempts is not numeric
+ * or is NaN, preventing unexpected infinite retries.
+ */
+describe('fetchRetry non numeric attempts', {concurrency:false}, () => {
+  it('throws when attempts is NaN', async () => {
+    await assert.rejects(
+      async () => await fetchRetry('http://e', {}, Number('foo')), // executes with NaN attempts
+      (err) => err.message === 'attempts must be numeric' // validates rejection reason
+    );
+  });
+  it('throws when attempts is not a number', async () => {
+    await assert.rejects(
+      async () => await fetchRetry('http://f', {}, '2'), // executes with string attempts
+      (err) => err.message === 'attempts must be numeric' // validates rejection reason
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- validate attempts numeric in request retry logic
- test non-numeric attempts path

## Testing
- `npm test` *(fails: test suite 68 tests, 57 failing)*

------
https://chatgpt.com/codex/tasks/task_b_684e160d390883229e84b7b33653e7ac