### PR TITLE
Handle CLI exit codes

### DIFF
--- a/scripts/purge-cdn.js
+++ b/scripts/purge-cdn.js
@@ -128,7 +128,14 @@ async function run(){
   qerrors(err, `run failed`, {args:process.argv.slice(2)}); // Logs error with command line context
   throw err; // Re-throws error to signal purge failure to calling processes
  }
-} // run function is exported but not executed automatically for manual control
+} // run function can be executed directly or imported for manual control
+
+if(require.main === module){
+ run().then(code => { if(code === 1) process.exitCode = 1; }).catch(err => { // Checks result to set exit code when run as CLI
+  qerrors(err, 'purge-cdn script failure', {args:process.argv.slice(2)}); // Logs execution failure context for debugging
+  process.exitCode = 1; // Ensures non-zero exit status for automation when errors occur
+ });
+}
 
 module.exports = {purgeCdn, run}; // exports functions for unit testing and reuse
 

--- a/scripts/updateHtml.js
+++ b/scripts/updateHtml.js
@@ -121,10 +121,10 @@ async function updateHtml(){
  * while remaining importable as a module. Proper error handling ensures
  * calling processes receive appropriate exit codes.
  */
-if(require.main === module){ 
- updateHtml().catch(err => { // Handles async function failures when run directly
+if(require.main === module){
+ updateHtml().then(code => { if(code === 1) process.exitCode = 1; }).catch(err => { // Checks return code then handles failures when executed directly
   qerrors(err, 'updateHtml script failure', {args:process.argv.slice(2)}); // Logs failure context for debugging
-  process.exitCode = 1; // Sets failure exit code for calling processes (CI/CD systems)
+  process.exitCode = 1; // Ensures non-zero exit for CLI automation when errors occur
  });
 }
 

--- a/test/integration-purge.test.js
+++ b/test/integration-purge.test.js
@@ -89,3 +89,23 @@ describe('build update purge', {concurrency:false}, () => {
     assert.strictEqual(code, 200); // verify purge returned success code in offline mode
   });
 });
+
+// CLI exit code validation ensures purge script signals missing artifacts properly
+const {spawnSync} = require('node:child_process'); // spawn used to execute script directly
+
+describe('purge-cdn exit code', {concurrency:false}, () => {
+  let dir; // temporary working directory for isolated execution
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'purgeexit-')); // create temp directory for CLI test
+  });
+  afterEach(() => {
+    fs.rmSync(dir, {recursive:true, force:true}); // remove temp directory after test
+  });
+
+  it('returns exit code 1 when build.hash missing via CLI', () => {
+    const script = path.resolve(__dirname,'../scripts/purge-cdn.js'); // resolve script path for child process
+    const result = spawnSync(process.execPath, [script], {cwd: dir, env:{...process.env, CODEX:'True'}}); // run in offline mode without hash file
+    assert.strictEqual(result.status, 1); // process should exit with code 1 due to missing build.hash
+  });
+});
+

--- a/test/updateHtml.test.js
+++ b/test/updateHtml.test.js
@@ -97,3 +97,15 @@ describe('updateHtml', () => {
     assert.strictEqual(hash, '12345678'); // ensure returned hash unchanged from build.hash file
   });
 });
+
+// CLI exit code tests ensure process.exitCode reflects missing build artifacts
+const {spawnSync} = require('node:child_process'); // child process used to run script directly
+
+describe('updateHtml exit code', {concurrency:false}, () => {
+  it('returns exit code 1 when build.hash missing via CLI', () => {
+    fs.rmSync(path.join(tmpDir, 'build.hash')); // removes hash file to simulate missing artifact
+    const result = spawnSync(process.execPath, [path.resolve(__dirname,'../scripts/updateHtml.js')], {cwd: tmpDir, env:{...process.env}}); // runs script in new process
+    assert.strictEqual(result.status, 1); // validates process exited with code 1
+  });
+});
+


### PR DESCRIPTION
## Summary
- check return codes in `updateHtml.js` and set exit code when run directly
- add `require.main` block for purge-cdn CLI invocation and handle exit code
- add CLI exit code tests for updateHtml
- add CLI exit code tests for purge-cdn

## Testing
- `npm test` *(fails: Cannot find module 'env-var')*

------
https://chatgpt.com/codex/tasks/task_b_684e164c304083229b21636476640b2e