### PR TITLE
Add fallback when hashed CSS fails to load

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,8 +127,9 @@ function injectCss(){ // handles runtime stylesheet loading logic
   link.rel = 'stylesheet'; // declares relationship to browser
   link.type = 'text/css'; // MIME type for clarity across tools
   link.href = `${basePath}${cssFile}`; // resolves href using whichever file exists
+  link.onerror = () => { link.href = `${basePath}qore.css`; console.log(`injectCss fallback to ${link.href}`); }; // swaps to qore.css on load failure
   document.head.appendChild(link); // injects stylesheet into document
-  console.log(`injectCss is returning ${cssFile}`); // logs resolved filename
+  console.log(`injectCss is returning ${cssFile}`); // logs resolved filename when hashed file loads
  } catch(err){
   console.error('injectCss failed:', err.message); // logs any runtime failure
  }


### PR DESCRIPTION
## Summary
- inject fallback CSS if hashed file fails in `injectCss`

## Testing
- `npm run lint` *(fails: stylelint not found)*
- `npm test` *(fails: many tests fail)*

------
https://chatgpt.com/codex/tasks/task_b_684e162a4ea88322bfeedb5fbf257103