### PR TITLE
Update CSS reference handling

### DIFF
--- a/scripts/updateHtml.js
+++ b/scripts/updateHtml.js
@@ -72,16 +72,10 @@ async function updateHtml(){
   
   /*
    * CSS HASH REPLACEMENT
-   * Rationale: Regex pattern matches any CSS file with 8-character hex hash.
-   * Global flag (g) ensures all references in the file are updated in one pass.
-   * This handles cases where CSS is referenced multiple times (preload, link, etc.).
+   * Rationale: Single regex matches both qore.css and existing hashed filenames.
+   * Global flag (g) ensures all references update in one pass for consistency.
    */
-  let updated; //(declare variable for updated html)
-  if(/core\.[a-f0-9]{8}\.min\.css/.test(html)){ //(detect existing hashed reference)
-   updated = html.replace(/core\.[a-f0-9]{8}\.min\.css/g, `core.${hash}.min.css`); //(update existing hash)
-  } else {
-   updated = html.replace(/qore\.css/g, `core.${hash}.min.css`); //(replace qore.css when no hashed filename)
-  }
+  let updated = html.replace(/(?:qore\.css|core\.[a-f0-9]{8}\.min\.css)/g, `core.${hash}.min.css`); // replaces any css reference with current hashed filename
   
   /*
    * CDN PLACEHOLDER SUBSTITUTION

--- a/test/updateHtml.test.js
+++ b/test/updateHtml.test.js
@@ -96,6 +96,22 @@ describe('updateHtml', () => {
     assert.ok(updated.includes('core.12345678.min.css')); // verify qore.css was replaced with hashed filename
     assert.strictEqual(hash, '12345678'); // ensure returned hash unchanged from build.hash file
   });
+
+  /*
+   * MIXED CSS REFERENCES VALIDATION
+   *
+   * TEST STRATEGY:
+   * Validates that a file containing both qore.css and an outdated hashed file
+   * is fully updated to the current hash in one replacement pass.
+   */
+  it('handles file with qore.css and old hashed reference', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'index.html'), '<link href="qore.css">\n<link href="core.deadbeef.min.css">'); // html with mixed css references
+    const hash = await updateHtml(); // execute update on mixed html
+    const updated = fs.readFileSync(path.join(tmpDir, 'index.html'), 'utf8'); // read result for validation
+    const count = (updated.match(/core\.12345678\.min\.css/g) || []).length; // count occurrences of updated hash
+    assert.strictEqual(count, 2); // both references should be replaced
+    assert.strictEqual(hash, '12345678'); // returned hash remains correct
+  });
 });
 
 // CLI exit code tests ensure process.exitCode reflects missing build artifacts


### PR DESCRIPTION
## Summary
- simplify CSS reference replacement to a single regex in `updateHtml`
- cover mixed CSS reference scenarios in tests

## Testing
- `npm test` *(fails: Cannot find module 'env-var')*

------
https://chatgpt.com/codex/tasks/task_b_684e1ec9a02883228b270abe4698fcef