### PR TITLE
Validate count parameter

### DIFF
--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -90,9 +90,14 @@ async function getTime(url){
  * This approach simulates realistic user load while being respectful
  * to CDN infrastructure and providing reliable measurements.
  */
-async function measureUrl(url, count){ 
+async function measureUrl(url, count){
  console.log(`measureUrl is running with ${url},${count}`); // Logs test parameters for monitoring
  try {
+  if(!Number.isInteger(count) || count <= 0){ // validates request count as positive integer
+   const err = new Error('count must be positive integer'); // explicit error when count invalid
+   qerrors(err, 'measureUrl invalid count', {url,count}); // structured error logging for invalid parameter
+   throw err; // stops execution when validation fails
+  }
   /*
    * MANUAL CONCURRENCY CONTROL
    * Rationale: Processes requests in batches of QUEUE_LIMIT size

--- a/test/performance.test.js
+++ b/test/performance.test.js
@@ -88,3 +88,12 @@ describe('run without build.hash', {concurrency:false}, () => {
     assert.strictEqual(typeof result, 'number'); //(validate numeric return)
   });
 });
+
+describe('measureUrl invalid count', {concurrency:false}, () => {
+  it('rejects non-positive count', async () => {
+    await assert.rejects(
+      async () => await performance.measureUrl('http://a', 0), // invalid count should throw
+      err => err.message === 'count must be positive integer' // validates error message
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- validate `measureUrl` count parameter
- log and throw when count invalid
- test invalid count handling

## Testing
- `npm test` *(fails: Cannot find module 'env-var')*

------
https://chatgpt.com/codex/tasks/task_b_684e1ebf74348322a137efa5636723ef