### PR TITLE
Handle undefined currentScript

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,8 +120,9 @@ if (typeof window === 'undefined') {
 function injectCss(){ // handles runtime stylesheet loading logic
  console.log(`injectCss is running with ${document.currentScript && document.currentScript.src}`); // logs entry and script src
  try {
-  const scriptSrc = document.currentScript && document.currentScript.src ? document.currentScript.src : 'index.js'; // resolves running script path
-  const basePath = scriptSrc.slice(0, scriptSrc.lastIndexOf('/') + 1); // extracts directory path portion
+  const scriptEl = document.currentScript || document.scripts[document.scripts.length-1]; // selects last script when currentScript unavailable
+  const scriptSrc = scriptEl && scriptEl.src ? scriptEl.src : document.baseURI; // uses document base when inline or bundled
+  const basePath = scriptSrc.slice(0, scriptSrc.lastIndexOf('/') + 1); // extracts directory path portion for css
   const cssFile = `core.5c7df4d0.min.css`; // placeholder replaced during build
   const link = document.createElement('link'); // creates stylesheet link element
   link.rel = 'stylesheet'; // declares relationship to browser

--- a/test/index.browser.test.js
+++ b/test/index.browser.test.js
@@ -99,4 +99,16 @@ describe('browser injection', {concurrency:false}, () => {
     const link = document.querySelector('link[href*="core"]') || document.querySelector('link[href*="qore"]') || document.querySelector('style'); // searches for injected CSS in multiple forms
     assert.ok(link); // confirms CSS injection occurred in simulated browser environment
   });
+
+  it('injects when currentScript undefined', () => {
+    delete require.cache[require.resolve('../index.js')]; // resets module for re-injection
+    const extra = document.createElement('script'); // creates dummy script for src path
+    extra.src = '/scripts/test.js'; // sets src attribute to mimic script file
+    document.body.appendChild(extra); // appends script so it becomes last in DOM
+    document.currentScript = undefined; // simulates environment where currentScript is not defined
+    const modAgain = require('../index.js'); // re-requires module to trigger injection with fallback
+    assert.strictEqual(modAgain.serverSide, undefined); // ensures browser detection still true
+    const links = document.querySelectorAll('link[href*="core"]'); // gathers all injected links
+    assert.ok(links.length >= 1); // verifies at least one stylesheet link present
+  });
 });


### PR DESCRIPTION
## Summary
- compute script path when `document.currentScript` is null
- test browser injection fallback for missing `currentScript`

## Testing
- `npm test` *(fails: Cannot find module 'env-var')*

------
https://chatgpt.com/codex/tasks/task_b_684e1ec51d488322bddde9bc3d351993