### PR TITLE
Ensure axios.create returns new stub

### DIFF
--- a/test/environment-config.test.js
+++ b/test/environment-config.test.js
@@ -191,13 +191,13 @@ describe('request retry environment configuration', {concurrency:false}, () => {
   it('handles SOCKET_LIMIT environment variable', async () => {
     process.env.SOCKET_LIMIT = '25'; // sets custom socket limit
     
+    const axios = require('axios'); // imports axios for mocking before module load
+    const {mock} = require('node:test'); // imports mocking utilities for axios
+
+    mock.method(axios, 'get', async () => ({status: 200})); // stubs instance get before axios.create
+
     delete require.cache[require.resolve('../scripts/request-retry')]; // clears module cache for fresh import
-    const fetchRetry = require('../scripts/request-retry'); // imports fetchRetry with custom socket limit
-    
-    const axios = require('axios'); // imports axios for mocking
-    const {mock} = require('node:test'); // imports mocking utilities
-    
-    mock.method(axios, 'get', async () => ({status: 200})); // mocks successful response
+    const fetchRetry = require('../scripts/request-retry'); // imports fetchRetry with custom socket limit after stubbing
     
     // Should use custom socket limit (validated through successful execution)
     const result = await fetchRetry('http://test'); // executes request with custom socket configuration
@@ -217,13 +217,13 @@ describe('request retry environment configuration', {concurrency:false}, () => {
   it('handles invalid SOCKET_LIMIT values', async () => {
     process.env.SOCKET_LIMIT = 'invalid'; // sets invalid socket limit
     
+    const axios = require('axios'); // imports axios for mocking before module load
+    const {mock} = require('node:test'); // imports mocking utilities for axios
+
+    mock.method(axios, 'get', async () => ({status: 200})); // stubs instance get before axios.create
+
     delete require.cache[require.resolve('../scripts/request-retry')]; // clears module cache for fresh import
-    const fetchRetry = require('../scripts/request-retry'); // imports fetchRetry with invalid socket config
-    
-    const axios = require('axios'); // imports axios for mocking
-    const {mock} = require('node:test'); // imports mocking utilities
-    
-    mock.method(axios, 'get', async () => ({status: 200})); // mocks successful response
+    const fetchRetry = require('../scripts/request-retry'); // imports fetchRetry with invalid socket config after stubbing
     
     // Should fallback to default socket limit
     const result = await fetchRetry('http://test'); // executes request with invalid config

--- a/test/helper.js
+++ b/test/helper.js
@@ -29,7 +29,7 @@ const orig = Module.prototype.require; // Preserves original require function fo
  * Silent error logging stub that prevents console noise during testing
  * while maintaining the same function signature as the real qerrors module.
  */
-const axiosStub = {get: async ()=>({status:200}),create(){return this;}}; // HTTP client stub returning successful responses
+const axiosStub = {get: async ()=>({status:200}),create(){return {...this};}}; // HTTP client stub now returns fresh copy to isolate instances
 function axiosRetryStub(axiosInst,{retries=3,retryDelay=()=>0}={}){ // minimal retry interceptor for tests
   const originalGet=axiosInst.get; // preserves base get implementation
   axiosInst.get=async function(url,opts={}){ // wraps get with retry logic


### PR DESCRIPTION
## Summary
- improve axios stub isolation by returning a new object from `axios.create`
- adjust environment config tests to stub axios before loading module

## Testing
- `npm test` *(fails: Cannot find module 'env-var')*

------
https://chatgpt.com/codex/tasks/task_b_684e1eaa1f2c832281ae612c16c2e1fd