### PR TITLE
Fix injectCss error handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,11 @@ function injectCss(){ // handles runtime stylesheet loading logic
   link.rel = 'stylesheet'; // declares relationship to browser
   link.type = 'text/css'; // MIME type for clarity across tools
   link.href = `${basePath}${cssFile}`; // resolves href using whichever file exists
-  link.onerror = () => { link.href = `${basePath}qore.css`; console.log(`injectCss fallback to ${link.href}`); }; // swaps to qore.css on load failure
+  link.onerror = () => { // fallback handler in case hashed css fails to load
+    link.onerror = null; // avoid infinite retry if qore.css also fails
+    link.href = `${basePath}qore.css`; // fall back to unminified CSS for resiliency
+    console.log(`injectCss fallback to ${link.href}`); // log fallback path for debugging
+  }; // fallback ensures single execution even when qore.css missing
   document.head.appendChild(link); // injects stylesheet into document
   console.log(`injectCss is returning ${cssFile}`); // logs resolved filename when hashed file loads
  } catch(err){


### PR DESCRIPTION
## Summary
- update injectCss error handling to only run once

## Testing
- `npm test` *(fails: Cannot find module 'env-var')*

------
https://chatgpt.com/codex/tasks/task_b_684e1e907af883228bf84809d7ad0a9a