### PR TITLE
Fix logger use in scripts

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -153,7 +153,7 @@ async function build(){
   console.log(`build is returning ${hash}`); // Logs return value for debugging
   return hash; // Returns hash for programmatic usage
  } catch(err){
-  console.error('build failed:', err.message, {args:process.argv.slice(2)}); // Logs error with full context for debugging
+  qerrors(err, 'build failed', {args:process.argv.slice(2)}); // uses project logger for structured error output
   throw err; // Re-throws to allow caller to handle or terminate process
  }
 }
@@ -165,7 +165,7 @@ async function build(){
  */
 if(require.main === module){
  build().catch(err => { // Handles async failures when run directly
-  console.error('build script failure:', err.message, {args:process.argv.slice(2)}); // Logs error context for debugging
+  qerrors(err, 'build script failure', {args:process.argv.slice(2)}); // uses project logger for structured error output
   process.exitCode = 1; // Sets non-zero exit code to signal failure to calling processes
  });
 }

--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -249,7 +249,7 @@ async function run(){
   console.log(`run is returning ${returnVal}`); // Logs value returned for monitoring
   return returnVal; // returns first average to caller
  } catch(err){
-  console.error(`run failed:`, err.message, {args:process.argv.slice(2)}); // Logs failure with command line context
+  qerrors(err, 'run failed', {args:process.argv.slice(2)}); // uses project logger for structured error output
   throw err; // Re-throws error to allow caller to handle appropriately
  }
 }
@@ -261,7 +261,7 @@ async function run(){
  */
 if(require.main === module){
  run().catch(err => { // Handles async failures when run directly for CLI usage
-  console.error('performance script failure:', err.message, {args:process.argv.slice(2)}); // Logs error context for debugging
+  qerrors(err, 'performance script failure', {args:process.argv.slice(2)}); // uses project logger for structured error output
   process.exitCode = 1; // Signals failure status to calling processes
  });
 }


### PR DESCRIPTION
## Summary
- send errors through qerrors in build.js and performance.js

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_b_684e1e95759c8322a6d18b87dcce1b31