### PR TITLE
Trim env config string

### DIFF
--- a/scripts/utils/env-config.js
+++ b/scripts/utils/env-config.js
@@ -16,7 +16,7 @@ function parseEnvInt(name, def, min = 1, max = 1000){
 function parseEnvString(name, def){
   console.log(`parseEnvString is running with ${name},${def}`); // entry log
   try {
-    const result = envVar.get(name).default(def).asString(); // parse string
+    const result = envVar.get(name).default(def).asString().trim(); // parse string and strip spaces
     console.log(`parseEnvString is returning ${result}`); // return value
     return result; // success path
   } catch(err){

--- a/test/env-config-utils.test.js
+++ b/test/env-config-utils.test.js
@@ -68,6 +68,12 @@ describe('parseEnvString behavior', {concurrency:false}, () => {
     assert.strictEqual(result, 'value'); // should match provided value
   });
 
+  it('trims leading and trailing spaces', () => {
+    process.env.TEST_STR = '   spaced value   '; // variable with extra spaces
+    const result = parseEnvString('TEST_STR', 'default'); // parse trimmed
+    assert.strictEqual(result, 'spaced value'); // should trim whitespace
+  });
+
   it('returns default when variable missing', () => {
     delete process.env.TEST_STR; // ensure variable not present
     const result = parseEnvString('TEST_STR', 'default'); // parse without env var


### PR DESCRIPTION
## Summary
- trim whitespace in `parseEnvString`
- verify trim behavior in `env-config-utils.test.js`

## Testing
- `npm test` *(fails: Cannot find module 'env-var')*

------
https://chatgpt.com/codex/tasks/task_b_684e446b4b0c8322ae86d51ec12fa503