### PR TITLE
Fix CDN fallback with empty env var

### DIFF
--- a/scripts/updateHtml.js
+++ b/scripts/updateHtml.js
@@ -68,7 +68,8 @@ async function updateHtml(){
    * for different deployment environments (development, staging, production).
    * jsDelivr chosen as default for its reliability and global CDN presence.
    */
-  const cdnUrl = parseEnvString('CDN_BASE_URL', 'https://cdn.jsdelivr.net').replace(/\/$/, ''); // removes trailing slash so URL concatenation does not create double slashes
+  let cdnUrl = parseEnvString('CDN_BASE_URL', 'https://cdn.jsdelivr.net').replace(/\/$/, ''); // retrieves CDN url with trailing slash removed
+  if(cdnUrl.trim() === ''){ cdnUrl = 'https://cdn.jsdelivr.net'; } // ensures empty string falls back to default CDN
   
   /*
    * CSS HASH REPLACEMENT

--- a/test/updateHtml.test.js
+++ b/test/updateHtml.test.js
@@ -82,6 +82,21 @@ describe('updateHtml', () => {
   });
 
   /*
+   * EMPTY CDN URL VALIDATION
+   *
+   * TEST STRATEGY:
+   * Ensures that when CDN_BASE_URL is set to an empty string the default
+   * jsDelivr URL is inserted into HTML.
+   */
+  it('uses default CDN url when env value empty', async () => {
+    process.env.CDN_BASE_URL = ''; // intentionally blank to test default fallback
+    const hash = await updateHtml(); // execute update with blank CDN URL
+    const updated = fs.readFileSync(path.join(tmpDir, 'index.html'), 'utf8'); // read updated HTML for verification
+    assert.ok(updated.includes('https://cdn.jsdelivr.net')); // default should replace blank value
+    assert.strictEqual(hash, '12345678'); // returned hash should remain correct
+  });
+
+  /*
    * FALLBACK CSS REPLACEMENT VALIDATION
    * 
    * TEST STRATEGY:


### PR DESCRIPTION
## Summary
- default to jsDelivr CDN when `CDN_BASE_URL` env var is empty
- test empty `CDN_BASE_URL` handling in HTML updater

## Testing
- `npm test` *(fails: Cannot find module 'env-var')*

------
https://chatgpt.com/codex/tasks/task_b_684e446e01f08322b70347c914c9299c