### PR TITLE
Add integer check for fetch retry

### DIFF
--- a/scripts/request-retry.js
+++ b/scripts/request-retry.js
@@ -60,6 +60,8 @@ async function fetchRetry(url,opts={},attempts=3){
 
   if(typeof attempts!=='number'||Number.isNaN(attempts)){ console.log(`fetchRetry is returning attempts must be numeric`); throw new Error('attempts must be numeric'); } // validates numeric attempt parameter
 
+  if(!Number.isInteger(attempts)){ console.log(`fetchRetry is returning attempts must be an integer`); throw new Error('attempts must be an integer'); } // ensures deterministic retry count
+
   if(attempts < 1){ console.log(`fetchRetry is returning attempts must be >0`); throw new Error('attempts must be >0'); } // validates positive attempt count
  
  /*

--- a/test/request-retry.test.js
+++ b/test/request-retry.test.js
@@ -154,3 +154,19 @@ describe('fetchRetry non numeric attempts', {concurrency:false}, () => {
     );
   });
 });
+
+/*
+ * NON-INTEGER ATTEMPT VALIDATION
+ *
+ * TESTING SCOPE:
+ * Ensures fetchRetry rejects when attempts is a floating
+ * point number, preventing ambiguous retry counts.
+ */
+describe('fetchRetry non integer attempts', {concurrency:false}, () => {
+  it('throws when attempts is a float', async () => {
+    await assert.rejects(
+      async () => await fetchRetry('http://g', {}, 1.5),
+      (err) => err.message === 'attempts must be an integer'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- validate that retry attempts are integers in `fetchRetry`
- log and throw an error when attempts are not integers
- test rejection when attempts is a float

## Testing
- `npm test` *(fails: Cannot find module 'env-var')*

------
https://chatgpt.com/codex/tasks/task_b_684e4480be3483229fec3c59bb54736b