### PR TITLE
Fix CDN placeholder replacement

### DIFF
--- a/scripts/updateHtml.js
+++ b/scripts/updateHtml.js
@@ -86,7 +86,7 @@ async function updateHtml(){
    * - Production with production CDN
    * Global replacement ensures all CDN references are consistent.
    */
-  updated = updated.replace(/\{\{CDN_BASE_URL\}\}/g, cdnUrl); // Replaces CDN placeholder with actual URL
+  updated = updated.replace(/\{\{CDN_BASE_URL\}\}/g, () => cdnUrl); // passes function so "$" chars remain literal when inserting URL
   
   /*
    * HTML FILE UPDATE


### PR DESCRIPTION
## Summary
- ensure updateHtml's CDN placeholder replacement treats `$` characters literally

## Testing
- `npm test` *(fails: Cannot find module 'env-var')*

------
https://chatgpt.com/codex/tasks/task_b_684e4474fc8c83229769ab91fc648730