### PR TITLE
Fix zero request test expectation

### DIFF
--- a/test/edge-cases.test.js
+++ b/test/edge-cases.test.js
@@ -159,10 +159,12 @@ describe('performance edge cases', {concurrency:false}, () => {
     process.env.CODEX = 'True'; // forces offline mode for predictable testing
     delete require.cache[require.resolve('../scripts/performance')]; // clears module cache for fresh import
     const performance = require('../scripts/performance'); // imports performance module after cache clearing
-    
-    const result = await performance.measureUrl('http://test', 0); // measures with zero requests
-    assert.strictEqual(result, 0); // validates zero result for zero requests (0/0 = 0 in this context)
-    
+
+    await assert.rejects(
+      async () => await performance.measureUrl('http://test', 0), // verifies rejection when count is zero
+      err => err.message === 'count must be positive integer' // ensures message matches input validation requirement
+    );
+
     delete process.env.CODEX; // cleans up environment flag
   });
 


### PR DESCRIPTION
## Summary
- update edge-case test for zero request count to expect rejection
- ensure test uses assert.rejects with proper error message

## Testing
- `npm test` *(fails: Cannot find module 'env-var')*

------
https://chatgpt.com/codex/tasks/task_b_684e44838b708322965b10ec28831c51