### PR TITLE
Update fallback logger to log context

### DIFF
--- a/scripts/utils/logger.js
+++ b/scripts/utils/logger.js
@@ -10,9 +10,9 @@ try {
   logger = require('qerrors'); // Use qerrors when available for structured error logging
 } catch (err) {
   function fallbackLogger(error, msg, ctx) { // provides console.error fallback when qerrors missing
-    console.log(`fallbackLogger is running with ${error},${msg}`); // entry log for debugging
-    console.error(error, msg, ctx); // basic error output
-    console.log(`fallbackLogger is returning undefined`); // exit log for debugging
+    console.log(`fallbackLogger is running with ${error},${msg},${ctx}`); // entry log includes context info
+    console.error(error, msg, ctx); // basic error output with context
+    console.log(`fallbackLogger is returning undefined with context ${ctx}`); // exit log mentions context
   }
   logger = fallbackLogger; // assign fallback implementation
 }

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -58,8 +58,9 @@ describe('logger falls back without qerrors', {concurrency:false}, () => {
     const logger = require('../scripts/utils/logger'); // load logger with missing qerrors
     Module.prototype.require = orig; // restore require after module load
     const spy = mock.method(console, 'error', ()=>{}); // spy on console.error calls
-    logger('boom','msg'); // invoke logger to trigger console.error
+    logger('boom','msg','ctxVal'); // invoke logger to trigger console.error with context
     assert.strictEqual(spy.mock.callCount(),1); // ensure console.error was called once
     assert.strictEqual(spy.mock.calls[0].arguments[0],'boom'); // validate error argument passed
+    assert.strictEqual(spy.mock.calls[0].arguments[2],'ctxVal'); // validate context argument passed
   });
 });


### PR DESCRIPTION
## Summary
- log context in fallback console messages
- ensure tests check for the third argument

## Testing
- `npm test` *(fails: Cannot find module 'env-var')*

------
https://chatgpt.com/codex/tasks/task_b_684e4478709c83229b45514837a5f14c