### PR TITLE
Improve CSS injection discovery

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,10 +120,11 @@ if (typeof window === 'undefined') {
 function injectCss(){ // handles runtime stylesheet loading logic
  console.log(`injectCss is running with ${document.currentScript && document.currentScript.src}`); // logs entry and script src
  try {
-  let scriptEl = document.currentScript || document.querySelector('script[src*="qoreCSS" i]') || document.querySelector('script[src*="qorecss" i]'); // finds script when currentScript null for bundler compatibility
-  if(!scriptEl){ const list = document.getElementsByTagName('script'); scriptEl = list[list.length-1]; } // falls back to last script element when others fail
-  const scriptSrc = scriptEl && scriptEl.src ? scriptEl.src : 'index.js'; // resolves running script path using detected element
-  const basePath = scriptSrc.slice(0, scriptSrc.lastIndexOf('/') + 1); // extracts directory path portion
+  let scriptEl = document.currentScript; // uses current script element when available
+  if(!scriptEl){ scriptEl = document.querySelector('script[src$="index.js" i]'); } // detects loading via standard filename when currentScript missing
+  if(!scriptEl){ scriptEl = document.querySelector('[data-qorecss]'); } // detects custom attribute for flexible inclusion
+  const scriptSrc = scriptEl && scriptEl.src ? scriptEl.src : ''; // avoids errors when element or src missing
+  const basePath = scriptSrc ? scriptSrc.slice(0, scriptSrc.lastIndexOf('/') + 1) : document.baseURI; // defaults to document.baseURI when no script found
   const cssFile = `core.5c7df4d0.min.css`; // placeholder replaced during build
   const existing = Array.from(document.head.querySelectorAll('link')) // collects current link elements for reuse check
     .find(l => l.href.includes(cssFile) || l.href.includes('qore.css')); // searches for prior injection by hashed or fallback name


### PR DESCRIPTION
## Summary
- refine `injectCss` script detection
- fall back to baseURI when script el missing
- extend browser injection tests for new discovery logic

## Testing
- `npm test` *(fails: spawn node_modules/.bin/postcss ENOENT)*

------
https://chatgpt.com/codex/tasks/task_b_684e8036819883229e77a8ecd18a8735