### PR TITLE
Fix fallback loop in injectCss

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,12 @@ function injectCss(){ // handles runtime stylesheet loading logic
    link.rel = 'stylesheet'; // declares relationship to browser
    link.type = 'text/css'; // MIME type for clarity across tools
    link.href = `${basePath}${cssFile}`; // resolves href using whichever file exists
-   link.onerror = () => { link.href = `${basePath}qore.css`; console.log(`injectCss fallback to ${link.href}`); }; // swaps to qore.css on load failure
+   link.onerror = () => { // triggers when hashed css fails loading
+    if(link.href === `${basePath}qore.css`) return; // prevents infinite loop when fallback also fails
+    link.onerror = null; // disables handler after first invocation to stop repeated retries
+    link.href = `${basePath}qore.css`; // switches to fallback stylesheet
+    console.log(`injectCss fallback to ${link.href}`); // logs fallback action for debugging
+   }; // swaps to qore.css on load failure once
    document.head.appendChild(link); // injects stylesheet into document
    console.log(`injectCss is returning ${cssFile}`); // logs resolved filename when hashed file loads
   } else {

--- a/test/index.browser.test.js
+++ b/test/index.browser.test.js
@@ -107,4 +107,16 @@ describe('browser injection', {concurrency:false}, () => {
     const countAfter = document.head.querySelectorAll('link').length; // counts links after second load to verify no extra element
     assert.strictEqual(countBefore, countAfter); // ensures link count unchanged meaning no duplicate injection
   });
+
+  it('stops error handler after one failure', () => {
+    const link = document.querySelector('link'); // retrieves injected link element
+    const handler = link.onerror; // stores error handler for manual trigger
+    handler(); // simulates hashed CSS load failure
+    assert.ok(link.href.includes('qore.css')); // verifies fallback applied
+    assert.strictEqual(link.onerror, null); // ensures handler removed
+    const hrefAfter = link.href; // records href after fallback
+    link.dispatchEvent(new dom.window.Event('error')); // simulates second failure
+    assert.strictEqual(link.href, hrefAfter); // confirms href unchanged
+    assert.strictEqual(link.onerror, null); // handler remains disabled
+  });
 });


### PR DESCRIPTION
## Summary
- prevent repeated fallback assignments in injectCss
- add unit test for single-failure behavior

## Testing
- `npm test` *(fails: build edge cases and build error handling)*

------
https://chatgpt.com/codex/tasks/task_b_684e803369408322bbd971b716f2fc29