### PR TITLE
Ensure attempts finite in retry utility

### DIFF
--- a/scripts/request-retry.js
+++ b/scripts/request-retry.js
@@ -60,6 +60,8 @@ async function fetchRetry(url,opts={},attempts=3){
 
   if(typeof attempts!=='number'||Number.isNaN(attempts)){ console.log(`fetchRetry is returning attempts must be numeric`); throw new Error('attempts must be numeric'); } // validates numeric attempt parameter
 
+  if(!Number.isFinite(attempts)){ console.log(`fetchRetry is returning attempts must be finite`); throw new Error('attempts must be finite'); } // ensures attempts not Infinity or -Infinity
+
   if(!Number.isInteger(attempts)){ console.log(`fetchRetry is returning attempts must be an integer`); throw new Error('attempts must be an integer'); } // ensures deterministic retry count
 
   if(attempts < 1){ console.log(`fetchRetry is returning attempts must be >0`); throw new Error('attempts must be >0'); } // validates positive attempt count

--- a/test/request-retry.test.js
+++ b/test/request-retry.test.js
@@ -170,3 +170,19 @@ describe('fetchRetry non integer attempts', {concurrency:false}, () => {
     );
   });
 });
+
+/*
+ * INFINITE ATTEMPT VALIDATION
+ *
+ * TESTING SCOPE:
+ * Ensures fetchRetry rejects when attempts is Infinity, preventing
+ * runaway loops and maintaining deterministic retry behavior.
+ */
+describe('fetchRetry infinite attempts', {concurrency:false}, () => {
+  it('throws when attempts is Infinity', async () => {
+    await assert.rejects(
+      async () => await fetchRetry('http://h', {}, Infinity),
+      (err) => err.message === 'attempts must be finite'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- check for finite numeric attempts in `fetchRetry`
- raise clear error when attempts is not finite
- test for Infinity attempts error case

## Testing
- `npm test` *(fails: spawn node_modules/.bin/postcss ENOENT)*

------
https://chatgpt.com/codex/tasks/task_b_684e802b155c8322bc7a1ace1563c401