### PR TITLE
Handle trailing slash in CDN base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Configure the build and deployment process:
 
 ```bash
 # CDN Configuration
-CDN_BASE_URL=https://cdn.jsdelivr.net  # CDN endpoint for deployment
+CDN_BASE_URL=https://cdn.jsdelivr.net  # CDN endpoint for deployment (trailing slash removed automatically; defaults to jsDelivr when empty)
 MAX_CONCURRENCY=50                     # Performance test concurrency limit
 SOCKET_LIMIT=100                       # HTTP connection pool size
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -39,7 +39,7 @@ Configure performance testing behavior through environment variables:
 
 ```bash
 # CDN Configuration
-export CDN_BASE_URL=https://cdn.jsdelivr.net    # Primary CDN endpoint
+export CDN_BASE_URL=https://cdn.jsdelivr.net    # Primary CDN endpoint (trailing slash removed automatically; defaults to jsDelivr when empty)
 export MAX_CONCURRENCY=50                        # Maximum concurrent requests (1-1000)  
 export SOCKET_LIMIT=100                          # HTTP connection pool size (1-1000)
 

--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -27,7 +27,8 @@ const qerrors = require('./utils/logger'); // Centralized error logging with con
 const fs = require('fs'); // File system operations for reading/writing test results
 // Manual concurrency control implementation to replace p-limit per REPLITAGENT.md constraints
 const {parseEnvInt, parseEnvString, parseEnvBool} = require('./utils/env-config'); // adds boolean parser for CODEX detection
-const CDN_BASE_URL = parseEnvString('CDN_BASE_URL', 'https://cdn.jsdelivr.net'); // Environment-configurable CDN endpoint
+let CDN_BASE_URL = parseEnvString('CDN_BASE_URL', 'https://cdn.jsdelivr.net').replace(/\/$/, ''); // remove trailing slash for consistency
+if(CDN_BASE_URL.trim() === ''){ CDN_BASE_URL = 'https://cdn.jsdelivr.net'; } // fallback to jsDelivr when empty
 const MAX_CONCURRENCY = parseEnvInt('MAX_CONCURRENCY', 50, 1, 1000); // validates range 1-1000 with default 50
 const QUEUE_LIMIT = parseEnvInt('QUEUE_LIMIT', 5, 1, 100); // validates range 1-100 with default 5
 const HISTORY_MAX = 50; // maximum entries kept in performance history file


### PR DESCRIPTION
## Summary
- strip trailing slash when reading `CDN_BASE_URL`
- default to jsDelivr if the value becomes empty
- document the new behavior in README and performance docs

## Testing
- `npm test` *(fails: spawn node_modules/.bin/postcss ENOENT)*

------
https://chatgpt.com/codex/tasks/task_b_684e804228e08322bdcddde245c40c0e