### PR TITLE
Update CDN URL trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Configure the build and deployment process:
 
 ```bash
 # CDN Configuration
-CDN_BASE_URL=https://cdn.jsdelivr.net  # CDN endpoint for deployment
+CDN_BASE_URL=https://cdn.jsdelivr.net  # CDN endpoint for deployment; trailing slashes removed
 MAX_CONCURRENCY=50                     # Performance test concurrency limit
 SOCKET_LIMIT=100                       # HTTP connection pool size
 

--- a/scripts/updateHtml.js
+++ b/scripts/updateHtml.js
@@ -68,7 +68,7 @@ async function updateHtml(){
    * for different deployment environments (development, staging, production).
    * jsDelivr chosen as default for its reliability and global CDN presence.
    */
-  let cdnUrl = parseEnvString('CDN_BASE_URL', 'https://cdn.jsdelivr.net').replace(/\/$/, ''); // retrieves CDN url with trailing slash removed
+  let cdnUrl = parseEnvString('CDN_BASE_URL', 'https://cdn.jsdelivr.net').replace(/\/+$/, ''); // trims trailing slash characters for consistent urls
   if(cdnUrl.trim() === ''){ cdnUrl = 'https://cdn.jsdelivr.net'; } // ensures empty string falls back to default CDN
   
   /*

--- a/test/updateHtml.test.js
+++ b/test/updateHtml.test.js
@@ -81,6 +81,15 @@ describe('updateHtml', () => {
     assert.strictEqual(hash, '12345678'); // validates function returns correct hash value
   });
 
+  it('trims trailing slashes from CDN url', async () => {
+    process.env.CDN_BASE_URL = 'http://testcdn///'; // sets CDN with extra slashes to test trimming
+    const hash = await updateHtml(); // executes HTML update
+    const updated = fs.readFileSync(path.join(tmpDir, 'index.html'), 'utf8'); // read updated HTML
+    assert.ok(updated.includes('http://testcdn')); // confirm url normalized without trailing slashes
+    assert.ok(!updated.includes('http://testcdn///')); // ensure extraneous slashes removed
+    assert.strictEqual(hash, '12345678'); // hash remains unchanged
+  });
+
   /*
    * EMPTY CDN URL VALIDATION
    *


### PR DESCRIPTION
## Summary
- handle multiple trailing slashes in `updateHtml.js`
- test CDN URLs with extra slashes
- document CDN URL trimming in README

## Testing
- `CODEX=True npm test` *(fails: 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_b_684e8027d99c83228247bfc51545fb90