### PR TITLE
Normalize CDN URLs consistently

### DIFF
--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -27,7 +27,7 @@ const qerrors = require('./utils/logger'); // Centralized error logging with con
 const fs = require('fs'); // File system operations for reading/writing test results
 // Manual concurrency control implementation to replace p-limit per REPLITAGENT.md constraints
 const {parseEnvInt, parseEnvString, parseEnvBool} = require('./utils/env-config'); // adds boolean parser for CODEX detection
-let CDN_BASE_URL = parseEnvString('CDN_BASE_URL', 'https://cdn.jsdelivr.net').replace(/\/$/, ''); // remove trailing slash for consistency
+let CDN_BASE_URL = parseEnvString('CDN_BASE_URL', 'https://cdn.jsdelivr.net').replace(/\/+$/, ''); // trims any number of trailing slashes for consistent base url
 if(CDN_BASE_URL.trim() === ''){ CDN_BASE_URL = 'https://cdn.jsdelivr.net'; } // fallback to jsDelivr when empty
 const MAX_CONCURRENCY = parseEnvInt('MAX_CONCURRENCY', 50, 1, 1000); // validates range 1-1000 with default 50
 const QUEUE_LIMIT = parseEnvInt('QUEUE_LIMIT', 5, 1, 100); // validates range 1-100 with default 5
@@ -272,4 +272,4 @@ if(require.main === module){
  });
 }
 
-module.exports = {getTime, measureUrl, run}; // exports functions for reuse and unit testing
+module.exports = {CDN_BASE_URL, getTime, measureUrl, run}; // exports normalized base url for tests and other functions for reuse

--- a/test/cdn-normalization.test.js
+++ b/test/cdn-normalization.test.js
@@ -1,0 +1,39 @@
+require('./helper'); // loads axios/qerrors stubs for test isolation
+const assert = require('node:assert'); // assertion library for validations
+const fs = require('node:fs'); // filesystem access for temporary files
+const path = require('node:path'); // path utilities for cross-platform tmp dirs
+const os = require('node:os'); // os module provides tmp directory location
+const {describe,it,beforeEach,afterEach} = require('node:test'); // test harness API
+const updateHtml = require('../scripts/updateHtml'); // script being compared
+let tmpDir; // temp directory for isolated execution
+let performance; // module under test for CDN normalization
+let origCwd; // original working directory
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(),'cdn-norm-')); // create isolated tmp dir
+  fs.writeFileSync(path.join(tmpDir,'build.hash'),'abcd1234'); // mock build hash
+  fs.writeFileSync(path.join(tmpDir,'index.html'),'{{CDN_BASE_URL}}'); // minimal html template
+  origCwd = process.cwd(); // save cwd for restoration
+  process.chdir(tmpDir); // run scripts inside tmp dir
+  process.env.CDN_BASE_URL = 'http://testcdn/////'; // base url with extra slashes for test
+  process.env.CODEX = 'True'; // offline mode to avoid network
+  delete require.cache[require.resolve('../scripts/performance')]; // reload module with env
+  performance = require('../scripts/performance'); // import fresh performance script
+});
+
+afterEach(() => {
+  process.chdir(origCwd); // restore original directory
+  fs.rmSync(tmpDir,{recursive:true,force:true}); // cleanup temporary files
+  delete process.env.CDN_BASE_URL; // remove env config to avoid bleed
+  delete process.env.CODEX; // clear offline flag
+});
+
+describe('cdn url normalization consistency',{concurrency:false},() => {
+  it('normalizes trailing slashes identically', async () => {
+    const perfBase = performance.CDN_BASE_URL; // normalized value from performance script
+    await updateHtml(); // run html updater with same env value
+    const html = fs.readFileSync(path.join(tmpDir,'index.html'),'utf8'); // read updated html
+    const htmlBase = html.trim(); // placeholder replaced value
+    assert.strictEqual(perfBase, htmlBase); // ensure both scripts match
+  });
+});


### PR DESCRIPTION
## Summary
- normalize CDN_BASE_URL in `scripts/performance.js` by removing all trailing slashes
- export the base URL for tests
- add a unit test to compare normalization between `performance.js` and `updateHtml.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684e8ffbc8e883229e69b249dbf00388