### PR TITLE
Update basePath fallback and add test

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ function injectCss(){ // handles runtime stylesheet loading logic
   if(!scriptEl){ scriptEl = document.querySelector('script[src$="index.js" i]'); } // detects loading via standard filename when currentScript missing
   if(!scriptEl){ scriptEl = document.querySelector('[data-qorecss]'); } // detects custom attribute for flexible inclusion
   const scriptSrc = scriptEl && scriptEl.src ? scriptEl.src : ''; // avoids errors when element or src missing
-  const basePath = scriptSrc ? scriptSrc.slice(0, scriptSrc.lastIndexOf('/') + 1) : document.baseURI; // defaults to document.baseURI when no script found
+  const basePath = scriptSrc ? scriptSrc.slice(0, scriptSrc.lastIndexOf('/') + 1) : document.baseURI.slice(0, document.baseURI.lastIndexOf('/') + 1); // uses directory portion of baseURI when script absent for consistent relative path
   const cssFile = `core.5c7df4d0.min.css`; // placeholder replaced during build
   const existing = Array.from(document.head.querySelectorAll('link')) // collects current link elements for reuse check
     .find(l => l.href.includes(cssFile) || l.href.includes('qore.css')); // searches for prior injection by hashed or fallback name

--- a/test/index.browser.test.js
+++ b/test/index.browser.test.js
@@ -142,4 +142,15 @@ describe('browser injection', {concurrency:false}, () => {
     const link = document.querySelector('link'); // retrieves injected link
     assert.ok(link.href.startsWith(document.baseURI)); // verifies fallback to document.baseURI
   });
+
+  it('derives base path from document.baseURI directory', () => {
+    dom.window.close(); // closes initial DOM before custom setup
+    dom = new JSDOM(`<!DOCTYPE html><html><head></head><body></body></html>`, {url:'https://example.com/page.html'}); // new DOM with page path for baseURI check
+    global.window = dom.window; // exposes new window to module
+    global.document = dom.window.document; // exposes new document to module
+    delete require.cache[require.resolve('../index.js')]; // ensures fresh module load
+    require('../index.js'); // triggers injection without script tag
+    const link = document.querySelector('link'); // retrieves injected link
+    assert.ok(link.href.startsWith('https://example.com/')); // expects directory portion of baseURI
+  });
 });


### PR DESCRIPTION
## Summary
- ensure injectCss() defaults to the directory portion of `document.baseURI`
- verify link href when script tag absent and page URL contains a filename

## Testing
- `CODEX=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_684e9041cb8c832284d92dd3235cfad6