### PR TITLE
Add CDN URL trimming utility

### DIFF
--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -26,9 +26,9 @@ const {performance} = require('perf_hooks'); // High-resolution timing API for a
 const qerrors = require('./utils/logger'); // Centralized error logging with contextual information
 const fs = require('fs'); // File system operations for reading/writing test results
 // Manual concurrency control implementation to replace p-limit per REPLITAGENT.md constraints
-const {parseEnvInt, parseEnvString, parseEnvBool} = require('./utils/env-config'); // adds boolean parser for CODEX detection
+const {parseEnvInt, parseEnvString, parseEnvBool, trimTrailingSlashes} = require('./utils/env-config'); // adds boolean parser and url normalizer
 
-let CDN_BASE_URL = parseEnvString('CDN_BASE_URL', 'https://cdn.jsdelivr.net').replace(/\/+$/, ''); // trims any number of trailing slashes for consistent base url
+let CDN_BASE_URL = trimTrailingSlashes(parseEnvString('CDN_BASE_URL', 'https://cdn.jsdelivr.net')); // ensures trailing slashes removed for consistent base url
 
 
 if(CDN_BASE_URL.trim() === ''){ CDN_BASE_URL = 'https://cdn.jsdelivr.net'; } // fallback to jsDelivr when empty

--- a/scripts/updateHtml.js
+++ b/scripts/updateHtml.js
@@ -23,7 +23,7 @@
 const fs = require('fs').promises; // File system operations using promises for consistent async patterns
 const path = require('path'); // path module for absolute path resolution during concurrent updates
 const qerrors = require('./utils/logger'); // Centralized error logging with contextual information
-const {parseEnvString} = require('./utils/env-config'); // standardizes CDN URL retrieval with fallback
+const {parseEnvString, trimTrailingSlashes} = require('./utils/env-config'); // standardizes CDN URL retrieval with fallback and trimming utility
 
 /*
  * HTML UPDATE FUNCTION
@@ -72,7 +72,7 @@ async function updateHtml(){
    * for different deployment environments (development, staging, production).
    * jsDelivr chosen as default for its reliability and global CDN presence.
    */
-  let cdnUrl = parseEnvString('CDN_BASE_URL', 'https://cdn.jsdelivr.net').replace(/\/+$/, ''); // trims trailing slash characters for consistent urls
+  let cdnUrl = trimTrailingSlashes(parseEnvString('CDN_BASE_URL', 'https://cdn.jsdelivr.net')); // trims trailing slash characters for consistent urls
   if(cdnUrl.trim() === ''){ cdnUrl = 'https://cdn.jsdelivr.net'; } // ensures empty string falls back to default CDN
   
   /*

--- a/scripts/utils/env-config.js
+++ b/scripts/utils/env-config.js
@@ -37,4 +37,16 @@ function parseEnvBool(name, def = false){
   }
 }
 
-module.exports = {parseEnvInt, parseEnvString, parseEnvBool};
+function trimTrailingSlashes(str){
+  console.log(`trimTrailingSlashes is running with ${str}`); // entry log
+  try {
+    const result = String(str).replace(/\/+$/, ''); // removes trailing slashes for consistent urls
+    console.log(`trimTrailingSlashes is returning ${result}`); // normalized result
+    return result; // success path
+  } catch(err){
+    console.log(`trimTrailingSlashes is returning ${str}`); // fallback on error
+    return str; // return original if replacement fails
+  }
+}
+
+module.exports = {parseEnvInt, parseEnvString, parseEnvBool, trimTrailingSlashes};

--- a/test/env-config-utils.test.js
+++ b/test/env-config-utils.test.js
@@ -16,7 +16,7 @@ require('./helper'); // ensures axios/qerrors stubs are active for isolation
 const assert = require('node:assert'); // Node.js assertion library for test validation
 const {describe, it, beforeEach, afterEach} = require('node:test'); // test framework components
 
-const {parseEnvInt, parseEnvString, parseEnvBool} = require('../scripts/utils/env-config'); // functions under test
+const {parseEnvInt, parseEnvString, parseEnvBool, trimTrailingSlashes} = require('../scripts/utils/env-config'); // functions under test including url normalizer
 
 let originalEnv; // snapshot of original environment
 
@@ -102,5 +102,15 @@ describe('parseEnvBool behavior', {concurrency:false}, () => {
     delete process.env.TEST_BOOL; // ensure variable missing
     const result = parseEnvBool('TEST_BOOL', false); // parse without env var
     assert.strictEqual(result, false); // default applied
+  });
+});
+
+/*
+ * TRAILING SLASH TRIM UTILITY VALIDATION
+ */
+describe('trimTrailingSlashes behavior', {concurrency:false}, () => {
+  it('removes extra trailing slashes from url', () => {
+    const result = trimTrailingSlashes('http://cdn///'); // url with multiple slashes
+    assert.strictEqual(result, 'http://cdn'); // should drop trailing characters
   });
 });


### PR DESCRIPTION
## Summary
- add `trimTrailingSlashes` utility for URL sanitization
- use this new function when obtaining `CDN_BASE_URL`
- test the trimming utility in env-config tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684f179251548322bc4a62912caa64c0