### PR TITLE
Fix DOM environment check in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,11 +93,12 @@ const qorecss = { // holds public API properties and helpers
  * ENVIRONMENT-SPECIFIC BEHAVIOR CONFIGURATION
  * 
  * DETECTION STRATEGY:
- * Uses typeof window to distinguish between Node.js (server) and browser
- * environments. This is more reliable than navigator checks and works
- * across different JavaScript runtime environments.
- */
-if (typeof window === 'undefined' && typeof module !== 'undefined' && module.exports) {
+ * Uses typeof window and navigator.userAgent to distinguish between Node.js
+ * (server) and browser environments. window.document is required for browser
+ * injection and navigator.userAgent containing 'jsdom' triggers server mode.
+ * This approach guards against JSDOM environments inadvertently injecting CSS.
+*/
+if ((typeof window === 'undefined' || (typeof navigator !== 'undefined' && navigator.userAgent && navigator.userAgent.toLowerCase().includes('jsdom'))) && typeof module !== 'undefined' && module.exports) {
   /*
    * SERVER-SIDE ENVIRONMENT CONFIGURATION
    * Rationale: In Node.js environments, the module provides file paths
@@ -107,7 +108,7 @@ if (typeof window === 'undefined' && typeof module !== 'undefined' && module.exp
   */
   module.exports = qorecss; // exposes API when running under Node
   module.exports.serverSide = true; // signals Node.js usage so consumers can skip browser injection
-} else if (typeof window !== 'undefined') {
+} else if (typeof window !== 'undefined' && window.document) {
   /*
    * BROWSER ENVIRONMENT AUTO-INJECTION
    * 

--- a/test/index.browser.test.js
+++ b/test/index.browser.test.js
@@ -153,4 +153,12 @@ describe('browser injection', {concurrency:false}, () => {
     const link = document.querySelector('link'); // retrieves injected link
     assert.ok(link.href.startsWith('https://example.com/')); // expects directory portion of baseURI
   });
+
+  it('skips injection when window exists without document', () => {
+    delete global.document; // removes document to simulate non-DOM window
+    global.window = {navigator:{userAgent:'Mozilla/5.0'}}; // minimal window object without DOM
+    delete require.cache[require.resolve('../index.js')]; // forces module reload
+    assert.doesNotThrow(() => { require('../index.js'); }); // ensures no runtime error without DOM
+    assert.strictEqual(global.qorecss, undefined); // verifies global API not exposed implying injection skipped
+  });
 });


### PR DESCRIPTION
## Summary
- detect jsdom and missing DOM nodes when deciding to inject CSS
- skip CSS injection when `window.document` is absent
- cover new behavior with test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684f17ac526083229bbfca62c25afb1b