### PR TITLE
Fix css regex and add core.min test

### DIFF
--- a/scripts/updateHtml.js
+++ b/scripts/updateHtml.js
@@ -77,10 +77,10 @@ async function updateHtml(){
   
   /*
    * CSS HASH REPLACEMENT
-   * Rationale: Single regex matches both qore.css and existing hashed filenames.
+   * Rationale: Single regex now also matches core.min.css to update legacy templates.
    * Global flag (g) ensures all references update in one pass for consistency.
    */
-  let updated = html.replace(/(?:qore\.css|core\.[a-f0-9]{8}\.min\.css)/g, `core.${hash}.min.css`); // replaces any css reference with current hashed filename
+  let updated = html.replace(/(?:qore\.css|core\.min\.css|core\.[a-f0-9]{8}\.min\.css)/g, `core.${hash}.min.css`); // ensures every CSS reference uses hashed filename
   
   /*
    * CDN PLACEHOLDER SUBSTITUTION

--- a/test/updateHtml.test.js
+++ b/test/updateHtml.test.js
@@ -121,6 +121,14 @@ describe('updateHtml', () => {
     assert.strictEqual(hash, '12345678'); // ensure returned hash unchanged from build.hash file
   });
 
+  it('replaces core.min.css with hashed file', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'index.html'), '<link href="core.min.css">'); // setup html with non-hashed css reference
+    const hash = await updateHtml(); // execute update to test core.min.css replacement
+    const updated = fs.readFileSync(path.join(tmpDir, 'index.html'), 'utf8'); // read updated html for assertion
+    assert.ok(updated.includes('core.12345678.min.css')); // ensure core.min.css updated to hashed filename
+    assert.strictEqual(hash, '12345678'); // verify returned hash unchanged from build.hash file
+  });
+
   /*
    * MIXED CSS REFERENCES VALIDATION
    *


### PR DESCRIPTION
## Summary
- update regex to replace `core.min.css` with hashed file
- document regex rationale in code
- test that `core.min.css` is replaced

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684f204c757883229b59bca1523b75dc