### PR TITLE
Rename concurrency argument to requestCount

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -13,14 +13,14 @@ The framework includes sophisticated performance measurement tools that validate
    npm install  # Installs all required dependencies
    ```
 
-2. **Execute Performance Tests**: 
+2. **Execute Performance Tests**:
    ```bash
-   # Run with default concurrency (5 requests)
+   # Run with default request count (5 requests)
    node scripts/performance.js
-   
-   # Run with custom concurrency (1-1000 requests)
+
+   # Run with custom request count (1-1000 requests)
    node scripts/performance.js 25
-   
+
    # Generate JSON output for CI/CD integration
    node scripts/performance.js 25 --json
    ```

--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -211,17 +211,17 @@ async function run(){
   if(jsonFlag){ args.splice(args.indexOf(`--json`),1); } // Removes flag from numeric arguments
   
   /*
-   * CONCURRENCY CONFIGURATION WITH SAFETY LIMITS
-   * Rationale: Configurable concurrency enables testing different load patterns
+   * REQUEST COUNT CONFIGURATION WITH SAFETY LIMITS
+   * Rationale: Configurable request count enables testing different load patterns
    * while safety limits prevent accidental DDoS of CDN endpoints.
    * Default of 5 provides meaningful load testing without being aggressive.
    * Range validation prevents resource exhaustion from invalid values.
    */
-  let concurrency = parseInt(args[0],10); 
-  if(Number.isNaN(concurrency) || concurrency < 1 || concurrency > 1000){ concurrency = 5; } // Validates range 1-1000 with sensible default
-  concurrency = Math.max(1, concurrency); // Ensures at least one request (prevents divide by zero)
-  if(concurrency > MAX_CONCURRENCY){ console.log(`run concurrency exceeds ${MAX_CONCURRENCY}`); concurrency = MAX_CONCURRENCY; } // Safety cap uses env derived limit
-  console.log(`run concurrency set to ${concurrency}`); // Logs final concurrency setting
+  let requestCount = parseInt(args[0],10); // parses CLI arg as integer
+  if(Number.isNaN(requestCount) || requestCount < 1 || requestCount > 1000){ requestCount = 5; } // validates range with sensible default
+  requestCount = Math.max(1, requestCount); // ensures at least one request to avoid divide by zero
+  if(requestCount > MAX_CONCURRENCY){ console.log(`run requestCount exceeds ${MAX_CONCURRENCY}`); requestCount = MAX_CONCURRENCY; } // caps by env derived limit
+  console.log(`run requestCount set to ${requestCount}`); // logs final request count setting
   
   /*
    * TEST EXECUTION ACROSS ALL ENDPOINTS
@@ -232,7 +232,7 @@ async function run(){
   const results = {}; // stores results for optional JSON output
   let firstAvg; // captures first URL average for function return
   for(const url of urls){
-   const avg = await measureUrl(url, concurrency); // Executes performance test
+   const avg = await measureUrl(url, requestCount); // Executes performance test
    console.log(`Average for ${url}: ${avg.toFixed(2)}ms`); // Displays human-readable results
    if(firstAvg === undefined){ firstAvg = avg; } // records first result for return value
    if(jsonFlag){ results[url] = avg; } // Stores results for JSON output

--- a/test/environment-config.test.js
+++ b/test/environment-config.test.js
@@ -156,7 +156,7 @@ describe('performance environment configuration', {concurrency:false}, () => {
     process.env.CDN_BASE_URL = 'https://custom-cdn.example.com'; // sets custom CDN base URL
     
     const originalArgv = process.argv; // preserves original arguments
-    process.argv = ['node', 'performance.js', '1']; // sets test arguments
+    process.argv = ['node', 'performance.js', '1']; // sets request count argument
     
     delete require.cache[require.resolve('../scripts/performance')]; // clears module cache for fresh import
     const performance = require('../scripts/performance'); // imports performance module with custom CDN

--- a/test/performance.test.js
+++ b/test/performance.test.js
@@ -59,7 +59,7 @@ describe('run trims history', {concurrency:false}, () => {
     fs.writeFileSync(path.join(tmpDir,'performance-results.json'), JSON.stringify(history)); //(create initial file)
     fs.writeFileSync(path.join(tmpDir, 'build.hash'), 'abcdef'); //(mock hash file required by run)
     process.chdir(tmpDir); //(switch cwd for script)
-    process.argv = ['node','scripts/performance.js','1','--json']; //(setup argv for run function)
+    process.argv = ['node','scripts/performance.js','1','--json']; //(setup argv with request count 1)
   });
   afterEach(() => {
     fs.rmSync(tmpDir, {recursive:true, force:true}); //(remove temp directory)
@@ -77,7 +77,7 @@ describe('run without build.hash', {concurrency:false}, () => {
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perf-')); //(temporary directory for file operations)
     process.chdir(tmpDir); //(switch cwd for script without hash)
-    process.argv = ['node','scripts/performance.js','1']; //(setup argv)
+    process.argv = ['node','scripts/performance.js','1']; //(setup argv with request count 1)
   });
   afterEach(() => {
     fs.rmSync(tmpDir, {recursive:true, force:true}); //(remove temp directory)
@@ -126,7 +126,7 @@ describe('CDN_BASE_URL trailing slashes', {concurrency:false}, () => {
     process.chdir(tmpDir); //(switch cwd for script)
     fs.writeFileSync(path.join(tmpDir, 'build.hash'), 'abcdef'); //(mock hash file required by run)
     process.env.CDN_BASE_URL = 'http://testcdn///'; //(set trailing slashes for test)
-    process.argv = ['node','scripts/performance.js','1']; //(setup argv for run function)
+    process.argv = ['node','scripts/performance.js','1']; //(setup argv with request count 1)
     delete require.cache[require.resolve('../scripts/performance')]; //(reload module to apply env)
     performance = require('../scripts/performance'); //(import performance after env setup)
   });


### PR DESCRIPTION
## Summary
- rename `concurrency` argument in `scripts/performance.js` to `requestCount`
- document new request count parameter in performance docs
- update comments in tests for clarity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684f204eeedc8322b825d14275dccbf6