### PR TITLE
Handle query strings in script detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ function injectCss(){ // handles runtime stylesheet loading logic
   let scriptEl = document.currentScript; // uses current script element when available
   if(!scriptEl){ // falls back to iterating all script tags when currentScript missing
    const scripts = Array.from(document.getElementsByTagName('script')); // gathers all script elements for manual search
-   scriptEl = scripts.find(s=>s.src && s.src.toLowerCase().endsWith('index.js')); // finds script with src ending index.js ignoring case
+   scriptEl = scripts.find(s => { const src = s.src ? s.src.toLowerCase().replace(/[?#].*$/, '') : ''; return src.endsWith('index.js'); }); // strips query/hash so index.js?v=1 still matches
   }
   if(!scriptEl){ scriptEl = document.querySelector('[data-qorecss]'); } // detects custom attribute for flexible inclusion
   const scriptSrc = scriptEl && scriptEl.src ? scriptEl.src : ''; // avoids errors when element or src missing

--- a/test/index.browser.test.js
+++ b/test/index.browser.test.js
@@ -129,6 +129,15 @@ describe('browser injection', {concurrency:false}, () => {
     assert.ok(link.href.startsWith('https://cdn.example.com/assets/')); // verifies base path from script src
   });
 
+  it('detects script src with query string', () => {
+    const script = document.createElement('script'); // creates script for query test
+    script.src = 'https://cdn.example.com/lib/index.js?v=1'; // query ensures detection strips parameters
+    document.body.appendChild(script); // attaches script to DOM for search
+    require('../index.js'); // loads module expecting injection
+    const link = document.querySelector('link'); // reads injected link element
+    assert.ok(link.href.startsWith('https://cdn.example.com/lib/')); // confirms base path resolved ignoring query
+  });
+
   it('uses data-qorecss attribute when provided', () => {
     const script = document.createElement('script'); // creates attribute-based script
     script.src = 'https://cdn.example.com/data/script.js'; // src unrelated to index.js


### PR DESCRIPTION
## Summary
- fix script tag search to ignore query/hash pieces when locating `index.js`
- note query/fragment stripping in comments
- test query-string scenario in browser injection tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684f204943d88322b5e1af73ad458555