### PR TITLE
Improve link cleanup regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,8 @@ function injectCss(){ // handles runtime stylesheet loading logic
 
   const cssFile = `core.5c7df4d0.min.css`; // placeholder replaced during build
   const links = Array.from(document.head.querySelectorAll('link')); // grabs all current link elements to manage updates
-  links.forEach(l => { const file = (l.getAttribute('href') || '').split('/').pop(); if(file.startsWith('core.') && !file.includes(cssFile)){ l.remove(); console.log(`injectCss removed outdated ${l.href}`); } }); // removes old hashed links that don't match the new hash
+  const coreRegex = /^core(?:\.[a-f0-9]{8})?\.min\.css$/; // targets only hashed or fallback core filenames for cleanup
+  links.forEach(l => { const file = (l.getAttribute('href') || '').split('/').pop(); if(coreRegex.test(file) && !file.includes(cssFile)){ l.remove(); console.log(`injectCss removed outdated ${l.href}`); } }); // removes old hashed links that don't match the new hash while leaving unrelated files
   const existing = links.find(l => l.href.includes(cssFile) || l.href.includes('qore.css')); // searches for prior injection by hashed or fallback name after cleanup
   if(!existing){ // avoids duplicate injection when link already present
    const link = document.createElement('link'); // creates stylesheet link element

--- a/test/index.browser.test.js
+++ b/test/index.browser.test.js
@@ -176,4 +176,15 @@ describe('browser injection', {concurrency:false}, () => {
     assert.ok(links[0].href.includes('core.abcdef12.min.css')); // ensure new hash present
     fs.unlinkSync(tmpPath); // cleanup temporary script file
   });
+
+  it('keeps unrelated core files intact', () => {
+    const extra = document.createElement('link'); // prepares additional stylesheet for removal test
+    extra.href = 'core.extra.css'; // unrelated file should not match regex in injectCss
+    extra.rel = 'stylesheet'; // standard rel value for CSS link
+    document.head.appendChild(extra); // injects unrelated stylesheet before loading module
+    require('../index.js'); // triggers injectCss which should leave extra file untouched
+    const links = Array.from(document.head.querySelectorAll('link')); // collects all link elements after injection
+    assert.strictEqual(links.length, 2); // expect new core hash plus existing extra file
+    assert.ok(links.some(l => l.href.endsWith('core.extra.css'))); // verifies extra file still present after injection
+  });
 });


### PR DESCRIPTION
## Summary
- tighten old link cleanup with hashed filename regex
- test that unrelated core.extra.css is untouched

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684f589073a08322888b07b044476dd4