### PR TITLE
Fix injectCss fallback selector

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ function injectCss(){ // handles runtime stylesheet loading logic
     }catch{return false;} // ignores scripts with bad URLs
    });
   }
-  if(!scriptEl){ scriptEl = document.querySelector('[data-qorecss]'); } // detects custom attribute for flexible inclusion
+  if(!scriptEl){ scriptEl = document.querySelector('script[data-qorecss]'); } // selects only script elements for reliable base path
   const scriptSrc = scriptEl && scriptEl.src ? scriptEl.src : ''; // avoids errors when element or src missing
   let basePath = ''; // default empty base path
   if (scriptSrc) {


### PR DESCRIPTION
## Summary
- ensure injectCss only scans script elements by data attribute
- verify package test suite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684fb8ef7fec83228f7e42dc4b4ea4ce