### PR TITLE
Handle fallback link cleanup in injectCss

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,8 +161,11 @@ function injectCss(){ // handles runtime stylesheet loading logic
   const links = Array.from(document.head.querySelectorAll('link')); // grabs all current link elements to manage updates
   const coreRegex = /^core(?:\.[a-f0-9]{8})?\.min\.css$/; // targets only hashed or fallback core filenames for cleanup
   links.forEach(l => { const file = (l.getAttribute('href') || '').split('/').pop(); if(coreRegex.test(file) && !file.includes(cssFile)){ l.remove(); console.log(`injectCss removed outdated ${l.href}`); } }); // removes old hashed links that don't match the new hash while leaving unrelated files
-  const existing = links.find(l => l.href.includes(cssFile) || l.href.includes('qore.css')); // searches for prior injection by hashed or fallback name after cleanup
-  if(!existing){ // avoids duplicate injection when link already present
+  const freshLinks = Array.from(document.head.querySelectorAll('link')); // re-queries after removals for up-to-date list
+  const existing = freshLinks.find(l => l.href.includes(cssFile)); // searches for injected hashed file
+  if(!existing){ // injects new file when hashed version not present
+   const fallback = freshLinks.find(l => l.href.includes('qore.css')); // detects plain qore.css link for cleanup
+   if(fallback){ fallback.remove(); console.log(`injectCss removed fallback ${fallback.href}`); } // cleans up old non-hashed link
    const link = document.createElement('link'); // creates stylesheet link element
    link.rel = 'stylesheet'; // declares relationship to browser
    link.type = 'text/css'; // MIME type for clarity across tools

--- a/test/index.browser.test.js
+++ b/test/index.browser.test.js
@@ -194,4 +194,16 @@ describe('browser injection', {concurrency:false}, () => {
     assert.strictEqual(links.length, 2); // expect new core hash plus existing extra file
     assert.ok(links.some(l => l.href.endsWith('core.extra.css'))); // verifies extra file still present after injection
   });
+
+  it('replaces qore.css link with hashed file', () => {
+    const fallback = document.createElement('link'); // pre-existing plain CSS link for cleanup test
+    fallback.href = 'qore.css'; // href that should be removed when hashed file injected
+    fallback.rel = 'stylesheet'; // sets standard rel value
+    document.head.appendChild(fallback); // inserts fallback before module load
+    require('../index.js'); // triggers injection which should remove fallback
+    const links = Array.from(document.head.querySelectorAll('link')); // gathers final links after injection
+    assert.strictEqual(links.length, 1); // expects single stylesheet in document
+    assert.ok(links[0].href.includes('core.5c7df4d0.min.css')); // validates hashed css link present
+    assert.ok(!links[0].href.endsWith('qore.css')); // ensures fallback removed
+  });
 });


### PR DESCRIPTION
## Summary
- refresh link list after removing outdated links in `injectCss`
- delete `qore.css` fallback link when injecting the hashed file
- verify the fallback removal logic in browser tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684fbe8fcde08322a94741f0806588d6