### PR TITLE
Fix safeResolve fallback to absolute path

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@
  * providing an intuitive API for developers familiar with modern npm packages.
 */
 
+const path = typeof require === 'function' ? require('node:path') : {resolve:(_d,f)=>f}; // node path or fallback object for browser use
 let errLog; // holds qerrors function or console fallback
 try { // attempts qerrors for structured logging like logger utility
   errLog = require('qerrors'); // assigns qerrors when available for consistency
@@ -47,8 +48,9 @@ function safeResolve(file){ // resolves path when require is present or falls ba
   if(errLog){ errLog(err,'safeResolve failed',{file}); } // structured logging when qerrors present
   else { console.error('safeResolve failed:', err.message); } // fallback replicating old behavior
  } // logs unexpected errors
- console.log(`safeResolve is returning ${file}`); // logs fallback path for browsers
- return file; // returns plain path when require unavailable
+ const abs = path.resolve(__dirname, file); // absolute fallback ensures bundlers find correct file even without require
+ console.log(`safeResolve is returning ${abs}`); // logs absolute fallback path
+ return abs; // returns absolute path when require unavailable for browser bundling
 }
 
 const qorecss = { // holds public API properties and helpers

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -118,4 +118,14 @@ describe('index module', {concurrency:false}, () => {
     assert.doesNotThrow(() => require('../index.js')); // ensures safeResolve handles missing qerrors
     Module.prototype.require = orig; // restore require handler after test
   });
+
+  it('safeResolve falls back to absolute path when require.resolve missing', () => {
+    const idx = require.resolve('../index.js'); // capture module path for reload
+    const old = require.resolve; require.resolve = undefined; // simulate environment lacking require.resolve
+    delete require.cache[idx]; // clear module cache for reload
+    const modNoRes = require(idx); // load module with altered require
+    assert.ok(path.isAbsolute(modNoRes.coreCss)); // expect absolute core path from fallback
+    assert.ok(path.isAbsolute(modNoRes.variablesCss)); // expect absolute variables path from fallback
+    require.resolve = old; // restore original resolve function
+  });
 });


### PR DESCRIPTION
## Summary
- require `path` in index.js for absolute path resolution
- update `safeResolve` to return `path.resolve(__dirname, file)` when `require.resolve` fails
- ensure tests check for absolute fallback paths

## Testing
- `node --test --test-concurrency=1`

------
https://chatgpt.com/codex/tasks/task_b_684fc2630730832286b83c2d6fd6c326