### PR TITLE
Guard __dirname in safeResolve

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,8 @@ function safeResolve(file){ // resolves path when require is present or falls ba
   if(errLog){ errLog(err,'safeResolve failed',{file}); } // structured logging when qerrors present
   else { console.error('safeResolve failed:', err.message); } // fallback replicating old behavior
  } // logs unexpected errors
- const abs = path.resolve(__dirname, file); // absolute fallback ensures bundlers find correct file even without require
+ const baseDir = typeof __dirname === 'string' ? __dirname : ''; // guards __dirname so browsers without Node globals do not throw
+ const abs = path.resolve(baseDir, file); // absolute fallback ensures bundlers find correct file even without require
  console.log(`safeResolve is returning ${abs}`); // logs absolute fallback path
  return abs; // returns absolute path when require unavailable for browser bundling
 }

--- a/test/index.nodir.browser.test.js
+++ b/test/index.nodir.browser.test.js
@@ -1,0 +1,19 @@
+require('./helper');
+const assert = require('node:assert');
+const path = require('node:path');
+const fs = require('node:fs');
+const {describe, it} = require('node:test');
+let JSDOM; try { ({JSDOM} = require('jsdom')); } catch { JSDOM = null; }
+
+describe('browser without __dirname', {concurrency:false}, () => {
+  if(!JSDOM){ it('skips when jsdom missing', () => { assert.ok(true); }); return; }
+  it('loads index.js with __dirname undefined', () => {
+    const dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>', {runScripts:'dangerously', url:'https://example.com/'});
+    const script = fs.readFileSync(path.resolve(__dirname, '../index.js'), 'utf8');
+    dom.window.__dirname = undefined; // removes Node global so safeResolve uses fallback
+    assert.doesNotThrow(() => { dom.window.eval(script); }); // ensures no ReferenceError occurs
+    const link = dom.window.document.querySelector('link'); // grabs injected stylesheet element
+    assert.ok(link); // confirms CSS injection still runs
+    dom.window.close();
+  });
+});


### PR DESCRIPTION
## Summary
- avoid ReferenceError when `__dirname` isn't available
- add a regression test for browser environments without `__dirname`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68503289855c8322bd52632768da8786