### PR TITLE
Handle missing node:path

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,10 @@
  * providing an intuitive API for developers familiar with modern npm packages.
 */
 
-const path = typeof require === 'function' ? require('node:path') : {resolve:(_d,f)=>f}; // node path or fallback object for browser use
+let path; // holds node:path module or fallback when unavailable
+if(typeof require==='function'){ // ensures require exists before attempting load
+  try { path = require('node:path'); } catch { path = {resolve:(_d,f)=>f}; } // safe attempt to load node:path or fallback
+} else { path = {resolve:(_d,f)=>f}; } // browser environment fallback when require undefined
 let errLog; // holds qerrors function or console fallback
 try { // attempts qerrors for structured logging like logger utility
   errLog = require('qerrors'); // assigns qerrors when available for consistency

--- a/test/index.require-fallback.test.js
+++ b/test/index.require-fallback.test.js
@@ -1,0 +1,24 @@
+require('./helper');
+const assert = require('node:assert');
+const {describe,it} = require('node:test');
+
+describe('node:path missing but require present', {concurrency:false}, () => {
+  it('safeResolve returns input path', () => {
+    const vm = require('node:vm');
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const code = fs.readFileSync(path.resolve(__dirname,'../index.js'),'utf8');
+    const sandbox = {
+      require(id){ if(id==='node:path'){ const err=new Error("Cannot find module 'node:path'"); err.code='MODULE_NOT_FOUND'; throw err; } return require(id); },
+      module:{exports:{}},
+      exports:{},
+      console,
+      __dirname:path.resolve(__dirname,'..'),
+      __filename:path.resolve(__dirname,'../index.js')
+    };
+    vm.runInNewContext(code,sandbox,{filename:'index.js'});
+    const mod = sandbox.module.exports;
+    assert.strictEqual(mod.coreCss, './qore.css');
+    assert.strictEqual(mod.variablesCss, './variables.css');
+  });
+});


### PR DESCRIPTION
## Summary
- attempt to load `node:path` in `index.js` and fall back to a dummy resolver when unavailable
- add a unit test verifying safeResolve works when `node:path` cannot be loaded

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68504ffa0f748322bd03ff8378f2cb1c