### PR TITLE
Fix fallback removal when hashed stylesheet present

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,10 +172,10 @@ function injectCss(){ // handles runtime stylesheet loading logic
     if(coreRegex.test(file) && !file.includes(cssFile)){ l.remove(); console.log(`injectCss removed outdated ${l.href}`); } // removes hashed links not matching new hash
   }); // iterates existing links to remove stale hashes
   const freshLinks = Array.from(document.head.querySelectorAll('link')); // re-queries after removals for up-to-date list
+  const fallback = freshLinks.find(l => l.href.includes('qore.css')); // locates plain qore.css link for unconditional removal
+  if(fallback){ fallback.remove(); console.log(`injectCss removed fallback ${fallback.href}`); } // ensures fallback always removed for hashed usage
   const existing = freshLinks.find(l => l.href.includes(cssFile)); // searches for injected hashed file
   if(!existing){ // injects new file when hashed version not present
-   const fallback = freshLinks.find(l => l.href.includes('qore.css')); // detects plain qore.css link for cleanup
-   if(fallback){ fallback.remove(); console.log(`injectCss removed fallback ${fallback.href}`); } // cleans up old non-hashed link
    const link = document.createElement('link'); // creates stylesheet link element
    link.rel = 'stylesheet'; // declares relationship to browser
    link.type = 'text/css'; // MIME type for clarity across tools

--- a/test/index.browser.test.js
+++ b/test/index.browser.test.js
@@ -218,4 +218,19 @@ describe('browser injection', {concurrency:false}, () => {
     assert.ok(links[0].href.includes('core.5c7df4d0.min.css')); // validates hashed css link present
     assert.ok(!links[0].href.endsWith('qore.css')); // ensures fallback removed
   });
+
+  it('removes fallback when hash already present', () => {
+    const hashed = document.createElement('link'); // pre-existing hashed stylesheet to simulate prior injection
+    hashed.href = 'core.5c7df4d0.min.css'; // matching current hash value for detection
+    hashed.rel = 'stylesheet'; // rel attribute ensures valid stylesheet element
+    document.head.appendChild(hashed); // adds hashed file before module load
+    const fallback = document.createElement('link'); // fallback stylesheet link for removal test
+    fallback.href = 'qore.css'; // href targeted by injectCss cleanup logic
+    fallback.rel = 'stylesheet'; // ensures element recognized as stylesheet
+    document.head.appendChild(fallback); // adds fallback before module load
+    require('../index.js'); // loads module which should remove fallback but keep hash
+    const links = Array.from(document.head.querySelectorAll('link')); // collects remaining link elements post injection
+    assert.strictEqual(links.length, 1); // expects only hashed stylesheet to remain
+    assert.ok(links[0].href.includes('core.5c7df4d0.min.css')); // verifies hashed stylesheet retained
+  });
 });


### PR DESCRIPTION
## Summary
- remove fallback `qore.css` even if hashed core file already exists
- ensure browser test covers fallback removal with preexisting hashed stylesheet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685067264e948322a212b2dc22260fe2