### PR TITLE
Fix browser fallback on CSS load failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,7 +180,7 @@ function injectCss(){ // handles runtime stylesheet loading logic
    link.rel = 'stylesheet'; // declares relationship to browser
    link.type = 'text/css'; // MIME type for clarity across tools
    link.href = `${basePath}${cssFile}`; // resolves href using whichever file exists
-   link.onerror = () => { link.href = `${basePath}qore.css`; console.log(`injectCss fallback to ${link.href}`); }; // swaps to qore.css on load failure
+   link.onerror = () => { link.onerror = null; link.href = `${basePath}qore.css`; console.log(`injectCss fallback to ${link.href}`); }; // disables handler then swaps to qore.css on load failure
    document.head.appendChild(link); // injects stylesheet into document
    console.log(`injectCss is returning ${cssFile}`); // logs resolved filename when hashed file loads
   } else {

--- a/test/index.browser.test.js
+++ b/test/index.browser.test.js
@@ -233,4 +233,16 @@ describe('browser injection', {concurrency:false}, () => {
     assert.strictEqual(links.length, 1); // expects only hashed stylesheet to remain
     assert.ok(links[0].href.includes('core.5c7df4d0.min.css')); // verifies hashed stylesheet retained
   });
+
+  it('removes onerror after fallback to prevent loop', () => {
+    require('../index.js'); // triggers injection to create link with handler
+    const link = document.querySelector('link'); // retrieves injected stylesheet link
+    const handle = link.onerror; // stores onerror for manual invocation
+    handle(); // simulate load error to trigger fallback
+    assert.ok(link.href.endsWith('qore.css')); // verifies fallback applied
+    assert.strictEqual(link.onerror, null); // ensures handler removed after invocation
+    link.href = 'again.css'; // resets href to check for loop
+    if(link.onerror){ link.onerror(); } // would re-trigger if handler not removed
+    assert.strictEqual(link.href, 'again.css'); // confirms href unchanged meaning no loop
+  });
 });


### PR DESCRIPTION
## Summary
- disable `link.onerror` after it fires to stop loops
- add test verifying fallback handler only runs once

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68506d6b00848322be94df3c75972a56