### PR TITLE
Handle null opts in fetchRetry

### DIFF
--- a/scripts/request-retry.js
+++ b/scripts/request-retry.js
@@ -55,7 +55,7 @@ axiosRetry(axiosInstance,{retryDelay:axiosRetry.exponentialDelay,shouldResetTime
  * - Network reality (allows for slow connections)
  * - Resource management (prevents hanging connections)
  */
-async function fetchRetry(url,opts={},attempts=3){
+async function fetchRetry(url,opts,attempts=3){
   console.log(`fetchRetry is running with ${url},${attempts}`); // logs entry with parameters
 
   if(typeof attempts!=='number'||Number.isNaN(attempts)){ console.log(`fetchRetry is returning attempts must be numeric`); throw new Error('attempts must be numeric'); } // validates numeric attempt parameter
@@ -65,6 +65,8 @@ async function fetchRetry(url,opts={},attempts=3){
   if(!Number.isInteger(attempts)){ console.log(`fetchRetry is returning attempts must be an integer`); throw new Error('attempts must be an integer'); } // ensures deterministic retry count
 
   if(attempts < 1){ console.log(`fetchRetry is returning attempts must be >0`); throw new Error('attempts must be >0'); } // validates positive attempt count
+
+  if(!opts||typeof opts!=='object'||Array.isArray(opts)||Object.getPrototypeOf(opts)!==Object.prototype){ opts={}; } // ensures opts is plain object to avoid runtime errors
  
  /*
   * TIMEOUT CONFIGURATION

--- a/test/request-retry.test.js
+++ b/test/request-retry.test.js
@@ -186,3 +186,22 @@ describe('fetchRetry infinite attempts', {concurrency:false}, () => {
     );
   });
 });
+
+/*
+ * NULL OPTIONS HANDLING
+ *
+ * TESTING SCOPE:
+ * Ensures fetchRetry gracefully handles a null opts parameter
+ * by substituting an empty object and applying default timeout.
+ */
+describe('fetchRetry null opts', {concurrency:false}, () => {
+  it('defaults timeout when opts is null', async () => {
+    let passedOpts; // captures options passed to axios for assertion
+    mock.method(axios, 'get', async (url, opts) => { passedOpts = opts; return {status:200}; }); // intercepts axios.get to record opts
+    delete require.cache[require.resolve('../scripts/request-retry')]; // reloads module after mock setup
+    fetchRetry = require('../scripts/request-retry'); // imports fetchRetry with new axios mock
+    const res = await fetchRetry('http://a', null); // executes with null opts to trigger defaulting
+    assert.strictEqual(res.status, 200); // validates successful response
+    assert.strictEqual(passedOpts.timeout, 10000); // confirms default timeout applied
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize non-object opts in request-retry
- test fetchRetry with null opts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68506d70b8688322958af8d0c585e2f9