### PR TITLE
Fix updateHtml regex for zipped files

### DIFF
--- a/scripts/updateHtml.js
+++ b/scripts/updateHtml.js
@@ -85,7 +85,7 @@ async function updateHtml(){
    * Rationale: Single regex now also matches core.min.css to update legacy templates.
    * Global flag (g) ensures all references update in one pass for consistency.
    */
-  let updated = html.replace(/(?:qore\.css|core\.min\.css|core\.[a-f0-9]{8}\.min\.css)/g, `core.${hash}.min.css`); // ensures every CSS reference uses hashed filename
+  let updated = html.replace(/(?:qore\.css|core\.min\.css|core\.[a-f0-9]{8}\.min\.css)(?!\.(?:gz|br))/g, `core.${hash}.min.css`); // negative lookahead avoids altering compressed files
   
   /*
    * CDN PLACEHOLDER SUBSTITUTION

--- a/test/updateHtml.test.js
+++ b/test/updateHtml.test.js
@@ -144,6 +144,14 @@ describe('updateHtml', () => {
     assert.strictEqual(count, 2); // both references should be replaced
     assert.strictEqual(hash, '12345678'); // returned hash remains correct
   });
+  it('leaves gzipped reference unchanged', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'index.html'), '<link href="core.aaaaaaaa.min.css.gz">'); // gzipped css should remain as generated
+    const hash = await updateHtml(); // execute update
+    const updated = fs.readFileSync(path.join(tmpDir, 'index.html'), 'utf8'); // retrieve updated html
+    assert.ok(updated.includes('core.aaaaaaaa.min.css.gz')); // verify compressed file kept same name
+    assert.strictEqual(hash, '12345678'); // returned hash should be unchanged
+  });
+
 
   it('writes file using utf8 encoding', async () => {
     let encOpt; // stores provided encoding option for assertion


### PR DESCRIPTION
## Summary
- narrow regex in `scripts/updateHtml.js` to avoid matching `.gz` and `.br` files
- add test ensuring gzipped CSS references remain untouched

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68506d795f048322b325be7f00f2ba52