### PR TITLE
Return link element from injectCss

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,9 +182,11 @@ function injectCss(){ // handles runtime stylesheet loading logic
    link.href = `${basePath}${cssFile}`; // resolves href using whichever file exists
    link.onerror = () => { link.onerror = null; link.href = `${basePath}qore.css`; console.log(`injectCss fallback to ${link.href}`); }; // disables handler then swaps to qore.css on load failure
    document.head.appendChild(link); // injects stylesheet into document
-   console.log(`injectCss is returning ${cssFile}`); // logs resolved filename when hashed file loads
+   console.log(`injectCss is returning ${link}`); // logs link element when hashed file loads
+   return link; // returns newly created link element for external use
   } else {
-   console.log(`injectCss is returning ${existing.href}`); // logs reuse of previously injected link
+   console.log(`injectCss is returning ${existing}`); // logs reuse of previously injected link element
+   return existing; // returns existing link element to caller
   }
  } catch(err){
   console.error('injectCss failed:', err.message); // logs any runtime failure

--- a/test/index.norequire.browser.test.js
+++ b/test/index.norequire.browser.test.js
@@ -14,4 +14,14 @@ describe('browser without require', {concurrency:false}, () => {
     assert.ok(dom.window.qorecss); // confirms global API exposed
     dom.window.close();
   });
+
+  it('injectCss returns link element reference', () => {
+    const dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>', {runScripts:'dangerously', url:'https://example.com/'});
+    const script = fs.readFileSync(path.resolve(__dirname, '../index.js'), 'utf8');
+    dom.window.eval(script); // executes script globally to expose injectCss
+    const first = dom.window.document.querySelector('link');
+    const returned = dom.window.injectCss(); // calls function again expecting same link
+    assert.strictEqual(returned, first); // verifies returned element matches existing link
+    dom.window.close();
+  });
 });


### PR DESCRIPTION
## Summary
- return the stylesheet link element from `injectCss`
- ensure logs reference returned element
- test that `injectCss()` returns the existing link element when called again

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68507fa52988832297c95301055fd358