### PR TITLE
Fix CODEX cleanup across tests

### DIFF
--- a/test/build-repeat.test.js
+++ b/test/build-repeat.test.js
@@ -21,6 +21,7 @@ beforeEach(() => {
 afterEach(() => {
   process.chdir(path.resolve(__dirname, '..')); // restore original working directory after test
   fs.rmSync(tmpDir, {recursive: true, force: true}); // clean up temporary directory to avoid interference
+  delete process.env.CODEX; // clear offline flag so later tests use default env
 });
 
 describe('build run twice', {concurrency:false}, () => {

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -25,6 +25,7 @@ const os = require('node:os'); // operating system utilities for temporary direc
 const {describe, it, beforeEach, afterEach} = require('node:test'); // Node.js native test framework components
 let build; // build function reference, assigned after module cache clearing
 let tmpDir; // temporary directory path for isolated test execution
+let prevCodex; // holds incoming CODEX value so tests can restore it after each run
 
 /*
  * TEST SETUP CONFIGURATION
@@ -35,6 +36,7 @@ let tmpDir; // temporary directory path for isolated test execution
  * build artifacts. This approach guarantees reproducible test results.
  */
 beforeEach(() => {
+  prevCodex = process.env.CODEX; // snapshot incoming CODEX for restoration after test
   process.env.CODEX = 'True'; // forces offline mode to prevent network calls during testing
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'buildtest-')); // creates unique temporary directory for test isolation
   fs.writeFileSync(path.join(tmpDir, 'qore.css'), 'body{}'); // minimal CSS input file for build processing
@@ -55,6 +57,7 @@ beforeEach(() => {
 afterEach(() => {
   process.chdir(path.resolve(__dirname, '..')); // restores original working directory
   fs.rmSync(tmpDir, {recursive: true, force: true}); // removes temporary directory and all contents
+  if(prevCodex !== undefined){ process.env.CODEX = prevCodex; } else { delete process.env.CODEX; } // restore or clear CODEX to avoid cross-test pollution
 });
 
 /*

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -25,6 +25,7 @@ const os = require('node:os'); // operating system utilities for temporary direc
 const {describe, it, before, after} = require('node:test'); // Node.js native test framework components
 let build, updateHtml; // script function references, assigned after module cache clearing
 let tmpDir; // temporary directory path for isolated test execution
+let prevCodex; // holds incoming CODEX value for cleanup after tests
 
 /*
  * INTEGRATION TEST SETUP
@@ -35,6 +36,7 @@ let tmpDir; // temporary directory path for isolated test execution
  * conditions where build and HTML update scripts must coordinate perfectly.
  */
 before(() => {
+  prevCodex = process.env.CODEX; // record incoming CODEX for restoration
   process.env.CODEX = 'True'; // forces offline mode to prevent network dependencies
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'integ-')); // creates unique temporary directory for test isolation
   fs.writeFileSync(path.join(tmpDir, 'qore.css'), 'body{}'); // minimal CSS input for build processing
@@ -57,6 +59,7 @@ before(() => {
 after(() => {
   process.chdir(path.resolve(__dirname, '..')); // restores original working directory
   fs.rmSync(tmpDir, {recursive: true, force: true}); // removes temporary directory and all contents
+  if(prevCodex !== undefined){ process.env.CODEX = prevCodex; } else { delete process.env.CODEX; } // restore or clear CODEX after suite
 });
 
 /*


### PR DESCRIPTION
## Summary
- restore CODEX env var after build.test suite
- clean CODEX env var in build-repeat and integration tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68507f99454483228e81ec8745d14c85