### PR TITLE
Fix injection search order

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,8 +155,9 @@ if (typeof window === 'undefined' && typeof module !== 'undefined' && module.exp
 function injectCss(){ // handles runtime stylesheet loading logic
  console.log(`injectCss is running with ${document.currentScript && document.currentScript.src}`); // logs entry and script src
  try {
-  let scriptEl = document.currentScript; // uses current script element when available
-  if(!scriptEl){ // falls back to iterating all script tags when currentScript missing
+  let scriptEl = document.querySelector('script[data-qorecss]'); // prioritizes explicit attribute for accurate base path
+  if(!scriptEl){ scriptEl = document.currentScript; } // falls back to currentScript when attribute missing
+  if(!scriptEl){ // iterates when neither attribute nor currentScript found
    const scripts = Array.from(document.getElementsByTagName('script')); // gathers all script elements for manual search
    scriptEl = scripts.find(s=>{ // searches for matching script by pathname
     try{ // protects against invalid URLs in script tags
@@ -164,7 +165,6 @@ function injectCss(){ // handles runtime stylesheet loading logic
     }catch{return false;} // ignores scripts with bad URLs
    });
   }
-  if(!scriptEl){ scriptEl = document.querySelector('script[data-qorecss]'); } // selects only script elements for reliable base path
   const scriptSrc = scriptEl && scriptEl.src ? scriptEl.src : ''; // avoids errors when element or src missing
   let basePath = ''; // default empty base path
   if (scriptSrc) {

--- a/test/index.browser.test.js
+++ b/test/index.browser.test.js
@@ -155,6 +155,20 @@ describe('browser injection', {concurrency:false}, () => {
     assert.ok(link.href.startsWith('https://cdn.example.com/data/')); // ensures detection via data attribute
   });
 
+  it('prioritizes data-qorecss over other index.js scripts', () => {
+    const other = document.createElement('script'); // unrelated index.js for fallback search
+    other.src = 'https://cdn.other.com/ignore/index.js'; // path not used when data attribute exists
+    document.body.appendChild(other); // adds non-attribute script first
+    const target = document.createElement('script'); // script marked for css base path
+    target.src = 'https://cdn.target.com/assets/index.js'; // correct base path for injection
+    target.setAttribute('data-qorecss', ''); // attribute marks this script
+    document.body.appendChild(target); // adds attribute script after other
+    delete require.cache[require.resolve('../index.js')]; // ensures fresh module load
+    require('../index.js'); // executes injection
+    const link = document.querySelector('link'); // link inserted by injectCss
+    assert.ok(link.href.startsWith('https://cdn.target.com/assets/')); // verifies attribute script used
+  });
+
   it('defaults to document.baseURI when script not found', () => {
     require('../index.js'); // loads module with no identifiable script
     const link = document.querySelector('link'); // retrieves injected link


### PR DESCRIPTION
## Summary
- prioritize `data-qorecss` search in `injectCss`
- test that the data attribute wins when multiple scripts exist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685088dfb9548322aec438405a7fc05e