### PR TITLE
Update docs for script attribute and perf results

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ const variablesPath = qorecss.getVariables();
 #### Browser Auto-injection
 ```html
 <!-- Automatically injects CSS when script loads -->
-<script src="node_modules/qorecss/index.js"></script>
+<script src="node_modules/qorecss/index.js" data-qorecss></script>
 ```
+The optional `data-qorecss` attribute ensures the loader can resolve its
+relative path correctly when scripts are served from nested directories.
 
 ## Customization
 
@@ -207,7 +209,10 @@ For self-hosting, see [docs/self-hosting.md](docs/self-hosting.md) for optimal s
 
 ### CDN Cache Purge
 After deployment run `node scripts/purge-cdn.js` to clear CDN caches so the latest hashed files are served. <!-- instructs users how to clear CDN -->
-You can optionally check CDN performance with `node scripts/performance.js` which measures response times. <!-- optional tool for CDN benchmarking -->
+You can optionally check CDN performance with `node scripts/performance.js` which
+measures response times. Adding the `--json` flag writes results to
+`performance-results.json` so trends can be tracked over time. <!-- optional tool for CDN benchmarking -->
+
 
 ## License
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -87,4 +87,6 @@ The testing system measures and reports:
 - **Average Response Time**: Mean response time across all requests
 - **Statistical Analysis**: Includes zero-count protection and range validation
 - **CDN Comparison**: Side-by-side performance comparison between providers
-- **Historical Tracking**: JSON output enables trend analysis over time
+- **Historical Tracking**: JSON output enables trend analysis over time. When
+  run with `--json`, results are appended to `performance-results.json` and the
+  file is trimmed to keep the latest 50 entries.


### PR DESCRIPTION
## Summary
- document `data-qorecss` script attribute for auto-injection
- note `--json` performance history output in README
- clarify performance results file in docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6850a6101fa88322a9e76b2a49faa3ba