### PR TITLE
docs: update perf result details

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ For self-hosting, see [docs/self-hosting.md](docs/self-hosting.md) for optimal s
 
 ### CDN Cache Purge
 After deployment run `node scripts/purge-cdn.js` to clear CDN caches so the latest hashed files are served. <!-- instructs users how to clear CDN -->
-You can optionally check CDN performance with `node scripts/performance.js` which measures response times. <!-- optional tool for CDN benchmarking -->
+You can optionally check CDN performance with `node scripts/performance.js --json` which measures response times and writes `performance-results.json`. <!-- explains json output file for tracking -->
 
 ## License
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -21,9 +21,10 @@ The framework includes sophisticated performance measurement tools that validate
    # Run with custom request count (1-1000 requests)
    node scripts/performance.js 25
 
-   # Generate JSON output for CI/CD integration
-   node scripts/performance.js 25 --json
-   ```
+    # Generate JSON output for CI/CD integration
+    node scripts/performance.js 25 --json
+    ```
+    Using `--json` appends results to `performance-results.json` for trend analysis. This file is uploaded by `.github/workflows/performance.yml` as an artifact. <!-- clarifies storage of performance history -->
 
 ### Advanced Features
 


### PR DESCRIPTION
## Summary
- document that `performance-results.json` is written when using `--json`
- clarify automated performance testing documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850abde30388322983406667783f05d